### PR TITLE
Fixing type mismatch error in MPI calls when compiling with gcc/gfortran version >=10

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -23,7 +23,7 @@ ifeq ($(BASE_FCOMP),ifort)
    CFLAGS := -O2
 else ifeq ($(BASE_FCOMP),gfortran)
    $(info "Using gcc/gfortran compilers" )
-   FFLAGS := -O2 -ffree-line-length-none -fallow-argument-mismatch -I${PETSC_DIR}/include
+   FFLAGS := -O2 -ffree-line-length-none -I${PETSC_DIR}/include
    CFLAGS := -O2
 else
    FFLAGS := -O2 -I${PETSC_DIR}/include

--- a/src/pic2d_BlockSetProc.f90
+++ b/src/pic2d_BlockSetProc.f90
@@ -109,9 +109,9 @@ SUBROUTINE IDENTIFY_BLOCK_BOUNDARIES
   USE CurrentProblemValues
   USE BlockAndItsBoundaries
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER errcode,ierr
 
@@ -284,9 +284,9 @@ SUBROUTINE INCLUDE_BLOCK_PERIODICITY
   USE CurrentProblemValues
   USE BlockAndItsBoundaries
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER errcode,ierr
   INTEGER stattus(MPI_STATUS_SIZE)
@@ -413,7 +413,7 @@ SUBROUTINE INCLUDE_BLOCK_PERIODICITY
 
      ! send  information about periodicity pairs to each process
      DO n = 1, N_of_processes-1
-        CALL MPI_SEND(all_periodic_messages(13:14,n), 2, MPI_INTEGER, n, Rank_of_process, MPI_COMM_WORLD, request, ierr)        
+        CALL MPI_SEND(all_periodic_messages(13:14,n), 2, MPI_INTEGER, n, Rank_of_process, MPI_COMM_WORLD, ierr)        
      END DO
      
 ! process own periodicity pair info
@@ -443,7 +443,7 @@ SUBROUTINE INCLUDE_BLOCK_PERIODICITY
   ELSE
      
 ! send periodic_message to zero-rank process
-     CALL MPI_SEND(periodic_message, 12, MPI_INTEGER, 0, Rank_of_process, MPI_COMM_WORLD, request, ierr)
+     CALL MPI_SEND(periodic_message, 12, MPI_INTEGER, 0, Rank_of_process, MPI_COMM_WORLD, ierr)
      
 ! receive information about periodicity pairs
      CALL MPI_RECV(ibufer(1:2), 2, MPI_INTEGER, 0, 0, MPI_COMM_WORLD, stattus, ierr) 
@@ -484,9 +484,9 @@ SUBROUTINE CALCULATE_BLOCK_OFFSET
   USE CurrentProblemValues
   USE BlockAndItsBoundaries
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER ierr
   INTEGER stattus(MPI_STATUS_SIZE)
@@ -553,7 +553,7 @@ SUBROUTINE CALCULATE_BLOCK_OFFSET
         IF (Rank_of_process_below.LT.0) bottom_right_inner_node = bottom_right_inner_node + N_of_nodes_to_solve_x  ! skip line of nodes along the bottom boundary
         ibufer(1) = bottom_right_inner_node
         ibufer(2) = N_of_nodes_to_solve_x
-        CALL MPI_SEND(ibufer, 2, MPI_INTEGER, Rank_of_process_right, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(ibufer, 2, MPI_INTEGER, Rank_of_process_right, Rank_of_process, MPI_COMM_WORLD, ierr) 
      END IF
 
      IF (Rank_of_process_left.GE.0) THEN
@@ -562,7 +562,7 @@ SUBROUTINE CALCULATE_BLOCK_OFFSET
         IF (Rank_of_process_below.LT.0) bottom_left_inner_node = bottom_left_inner_node + N_of_nodes_to_solve_x  ! skip line of nodes along the bottom boundary
         ibufer(1) = bottom_left_inner_node
         ibufer(2) = N_of_nodes_to_solve_x
-        CALL MPI_SEND(ibufer, 2, MPI_INTEGER, Rank_of_process_left, Rank_of_process, MPI_COMM_WORLD, request, ierr)
+        CALL MPI_SEND(ibufer, 2, MPI_INTEGER, Rank_of_process_left, Rank_of_process, MPI_COMM_WORLD, ierr)
      END IF
 
      IF (Rank_of_process_left.GE.0) THEN
@@ -584,7 +584,7 @@ SUBROUTINE CALCULATE_BLOCK_OFFSET
         left_top_inner_node = global_offset + N_of_nodes_to_solve_x * (N_of_nodes_to_solve_y-1) + 1
         IF (Rank_of_process_left.LT.0) left_top_inner_node = left_top_inner_node + 1  ! skip the node at the left boundary
         ibufer(1) = left_top_inner_node
-        CALL MPI_SEND(ibufer(1), 1, MPI_INTEGER, Rank_of_process_above, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(ibufer(1), 1, MPI_INTEGER, Rank_of_process_above, Rank_of_process, MPI_COMM_WORLD, ierr) 
      END IF
 
      IF (Rank_of_process_below.GE.0) THEN
@@ -592,7 +592,7 @@ SUBROUTINE CALCULATE_BLOCK_OFFSET
         left_bottom_inner_node = global_offset + 1
         IF (Rank_of_process_left.LT.0) left_bottom_inner_node = left_bottom_inner_node + 1  ! skip the node at the left boundary
         ibufer(1) = left_bottom_inner_node
-        CALL MPI_SEND(ibufer(1), 1, MPI_INTEGER, Rank_of_process_below, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(ibufer(1), 1, MPI_INTEGER, Rank_of_process_below, Rank_of_process, MPI_COMM_WORLD, ierr) 
      END IF
 
      IF (Rank_of_process_below.GE.0) THEN
@@ -629,7 +629,7 @@ SUBROUTINE CALCULATE_BLOCK_OFFSET
         IF (Rank_of_process_below.LT.0) bottom_right_inner_node = bottom_right_inner_node + N_of_nodes_to_solve_x  ! skip line of nodes along the bottom boundary
         ibufer(1) = bottom_right_inner_node
         ibufer(2) = N_of_nodes_to_solve_x
-        CALL MPI_SEND(ibufer, 2, MPI_INTEGER, Rank_of_process_right, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(ibufer, 2, MPI_INTEGER, Rank_of_process_right, Rank_of_process, MPI_COMM_WORLD, ierr) 
      END IF
 
      IF (Rank_of_process_left.GE.0) THEN
@@ -638,7 +638,7 @@ SUBROUTINE CALCULATE_BLOCK_OFFSET
         IF (Rank_of_process_below.LT.0) bottom_left_inner_node = bottom_left_inner_node + N_of_nodes_to_solve_x  ! skip line of nodes along the bottom boundary
         ibufer(1) = bottom_left_inner_node
         ibufer(2) = N_of_nodes_to_solve_x
-        CALL MPI_SEND(ibufer, 2, MPI_INTEGER, Rank_of_process_left, Rank_of_process, MPI_COMM_WORLD, request, ierr)
+        CALL MPI_SEND(ibufer, 2, MPI_INTEGER, Rank_of_process_left, Rank_of_process, MPI_COMM_WORLD, ierr)
      END IF
 
      IF (Rank_of_process_below.GE.0) THEN
@@ -658,7 +658,7 @@ SUBROUTINE CALCULATE_BLOCK_OFFSET
         left_top_inner_node = global_offset + N_of_nodes_to_solve_x * (N_of_nodes_to_solve_y-1) + 1
         IF (Rank_of_process_left.LT.0) left_top_inner_node = left_top_inner_node + 1  ! skip the node at the left boundary
         ibufer(1) = left_top_inner_node
-        CALL MPI_SEND(ibufer(1), 1, MPI_INTEGER, Rank_of_process_above, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(ibufer(1), 1, MPI_INTEGER, Rank_of_process_above, Rank_of_process, MPI_COMM_WORLD, ierr) 
      END IF
 
      IF (Rank_of_process_below.GE.0) THEN
@@ -666,7 +666,7 @@ SUBROUTINE CALCULATE_BLOCK_OFFSET
         left_bottom_inner_node = global_offset + 1
         IF (Rank_of_process_left.LT.0) left_bottom_inner_node = left_bottom_inner_node + 1  ! skip the node at the left boundary
         ibufer(1) = left_bottom_inner_node
-        CALL MPI_SEND(ibufer(1), 1, MPI_INTEGER, Rank_of_process_below, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(ibufer(1), 1, MPI_INTEGER, Rank_of_process_below, Rank_of_process, MPI_COMM_WORLD, ierr) 
      END IF
 
   END IF
@@ -679,9 +679,9 @@ SUBROUTINE ANALYZE_BOUNDARY_OBJECTS
 
   USE CurrentProblemValues
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER errcode,ierr
 

--- a/src/pic2d_Checkpoints.f90
+++ b/src/pic2d_Checkpoints.f90
@@ -17,10 +17,9 @@ SUBROUTINE SAVE_CHECKPOINT_MPIIO_2(n_sub)
   USE ExternalCircuit
 
   USE rng_wrapper
+  use mpi
 
   IMPLICIT NONE
-
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
   INTEGER stattus(MPI_STATUS_SIZE)
@@ -328,7 +327,7 @@ SUBROUTINE SAVE_CHECKPOINT_MPIIO_2(n_sub)
 
   IF (Rank_of_process.GT.0) THEN  
      myibufer(1) = Rank_of_process
-     CALL MPI_SEND(myibufer(1), 1, MPI_INTEGER, Rank_of_process-1, Rank_of_process, MPI_COMM_WORLD, request, ierr)
+     CALL MPI_SEND(myibufer(1), 1, MPI_INTEGER, Rank_of_process-1, Rank_of_process, MPI_COMM_WORLD, ierr)
   END IF
 
   IF (Rank_of_process.EQ.0) PRINT '("Created checkpoint report file ",A21)', filename_report
@@ -361,10 +360,9 @@ SUBROUTINE READ_CHECKPOINT_MPIIO_2
   USE ExternalCircuit
 
   USE rng_wrapper
+  use mpi
 
   IMPLICIT NONE
-
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
   INTEGER stattus(MPI_STATUS_SIZE)
@@ -646,7 +644,7 @@ SUBROUTINE READ_CHECKPOINT_MPIIO_2
 
   IF (Rank_of_process.GT.0) THEN  
      myibufer(1) = Rank_of_process
-     CALL MPI_SEND(myibufer(1), 1, MPI_INTEGER, Rank_of_process-1, Rank_of_process, MPI_COMM_WORLD, request, ierr)
+     CALL MPI_SEND(myibufer(1), 1, MPI_INTEGER, Rank_of_process-1, Rank_of_process, MPI_COMM_WORLD, ierr)
   END IF
 
   IF (Rank_of_process.EQ.0) PRINT '("Created checkpoint report file ",A20)', filename_report
@@ -716,10 +714,9 @@ SUBROUTINE SAVE_CHECKPOINT_POSIX(n_sub)
   USE ExternalCircuit
 
   USE rng_wrapper
+  use mpi
 
   IMPLICIT NONE
-
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
 
@@ -941,10 +938,9 @@ SUBROUTINE READ_CHECKPOINT_POSIX
   USE ExternalCircuit
 
   USE rng_wrapper
+  use mpi
 
   IMPLICIT NONE
-
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
 
@@ -1135,9 +1131,9 @@ SUBROUTINE READ_A_CHECKPOINT
   USE ParallelOperationValues
   USE Checkpoints, ONLY : T_cntr_to_continue
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER errcode,ierr
   

--- a/src/pic2d_CurProblemValues.f90
+++ b/src/pic2d_CurProblemValues.f90
@@ -74,10 +74,9 @@ SUBROUTINE INITIATE_PARAMETERS
   USE rng_wrapper
 
   USE PETSc_Solver
+  use mpi
   
   IMPLICIT NONE
-
-  INCLUDE 'mpif.h'
 
   LOGICAL exists
 
@@ -1519,9 +1518,9 @@ SUBROUTINE IDENTIFY_CLUSTER_BOUNDARIES
   USE CurrentProblemValues
   USE ClusterAndItsBoundaries
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER errcode,ierr
   INTEGER stattus(MPI_STATUS_SIZE)
@@ -1822,9 +1821,9 @@ SUBROUTINE INCLUDE_CLUSTER_PERIODICITY
   USE CurrentProblemValues
   USE ClusterAndItsBoundaries
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER errcode,ierr
   INTEGER stattus(MPI_STATUS_SIZE)
@@ -1967,7 +1966,7 @@ print '(4(2x,i4))', 0, all_periodic_messages(13:15,0)
 ! send  information about periodicity pairs to each process
         DO n = 1, N_processes_horizontal-1
 print '(4(2x,i4))', n, all_periodic_messages(13:15,n)
-           CALL MPI_SEND(all_periodic_messages(14:15,n), 2, MPI_INTEGER, n, Rank_horizontal, COMM_HORIZONTAL, request, ierr)        
+           CALL MPI_SEND(all_periodic_messages(14:15,n), 2, MPI_INTEGER, n, Rank_horizontal, COMM_HORIZONTAL, ierr)        
         END DO
      
 ! process own periodicity pair info
@@ -1996,7 +1995,7 @@ print '(4(2x,i4))', n, all_periodic_messages(13:15,n)
  
      ELSE
 ! send periodic_message to zero-rank cluster
-        CALL MPI_SEND(periodic_message, 13, MPI_INTEGER, 0, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+        CALL MPI_SEND(periodic_message, 13, MPI_INTEGER, 0, Rank_horizontal, COMM_HORIZONTAL, ierr) 
 ! receive information about periodicity pairs
         CALL MPI_RECV(ibufer(1:2), 2, MPI_INTEGER, 0, 0, COMM_HORIZONTAL, stattus, ierr) 
         IF (ibufer(1).GE.0) THEN
@@ -2044,7 +2043,7 @@ print '("Process ",i4," :: P.B. L/R/B/A :: ",4(1x,L1))', Rank_of_process, period
         PRINT '("INCLUDE_PERIODICITY :: master process ",i4," is periodically [X] connected to itself, L_period_X = ",f10.4)', Rank_of_process, L_period_X
      ELSE IF (periodic_boundary_X_left) THEN
 ! send 
-        CALL MPI_SEND(c_indx_x_min, 1, MPI_INTEGER, Rank_of_master_left, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(c_indx_x_min, 1, MPI_INTEGER, Rank_of_master_left, Rank_of_process, MPI_COMM_WORLD, ierr) 
 ! receive 
         CALL MPI_RECV(ibufer(1), 1, MPI_INTEGER, Rank_of_master_left, Rank_of_master_left, MPI_COMM_WORLD, stattus, ierr) 
         i_period_x = ibufer(1) - c_indx_x_min - 1
@@ -2057,7 +2056,7 @@ print '("Process ",i4," :: P.B. L/R/B/A :: ",4(1x,L1))', Rank_of_process, period
         i_period_x = c_indx_x_max - ibufer(1) - 1   ! last cell is overlapping
         L_period_X = DBLE(i_period_x)
 ! send
-        CALL MPI_SEND(c_indx_x_max, 1, MPI_INTEGER, Rank_of_master_right, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(c_indx_x_max, 1, MPI_INTEGER, Rank_of_master_right, Rank_of_process, MPI_COMM_WORLD, ierr) 
 ! report
         PRINT '("INCLUDE_PERIODICITY :: master process ",i4," communicated with process ",i4," and got L_period_X = ",f10.4)', Rank_of_process, Rank_of_master_right, L_period_X
      END IF
@@ -2068,7 +2067,7 @@ print '("Process ",i4," :: P.B. L/R/B/A :: ",4(1x,L1))', Rank_of_process, period
 
      IF (periodic_boundary_Y_below) THEN
 ! send 
-        CALL MPI_SEND(c_indx_y_min, 1, MPI_INTEGER, Rank_of_master_below, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(c_indx_y_min, 1, MPI_INTEGER, Rank_of_master_below, Rank_of_process, MPI_COMM_WORLD, ierr) 
 ! receive 
         CALL MPI_RECV(ibufer(1), 1, MPI_INTEGER, Rank_of_master_below, Rank_of_master_below, MPI_COMM_WORLD, stattus, ierr) 
         i_period_y = ibufer(1) - c_indx_y_min - 1
@@ -2081,7 +2080,7 @@ print '("Process ",i4," :: P.B. L/R/B/A :: ",4(1x,L1))', Rank_of_process, period
         i_period_y = c_indx_y_max - ibufer(1) - 1   ! last cell is overlapping
         L_period_Y = DBLE(i_period_y)   ! last cell is overlapping
 ! send
-        CALL MPI_SEND(c_indx_y_max, 1, MPI_INTEGER, Rank_of_master_above, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(c_indx_y_max, 1, MPI_INTEGER, Rank_of_master_above, Rank_of_process, MPI_COMM_WORLD, ierr) 
 ! report
         PRINT '("INCLUDE_PERIODICITY :: master process ",i4," communicated with process ",i4," and got L_period_Y = ",f10.4)', Rank_of_process, Rank_of_master_above, L_period_Y
      END IF
@@ -2113,7 +2112,7 @@ print '("Process ",i4," :: P.B. L/R/B/A :: ",4(1x,L1))', Rank_of_process, period
               ibufer(2*n)   = c_local_object_part(n_right(n))%segment_number
            END IF
         END DO
-        CALL MPI_SEND(ibufer(1:4), 4, MPI_INTEGER, Rank_of_master_right, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(ibufer(1:4), 4, MPI_INTEGER, Rank_of_master_right, Rank_of_process, MPI_COMM_WORLD, ierr) 
      END IF
 
      IF (connect_left) THEN
@@ -2125,7 +2124,7 @@ print '("Process ",i4," :: P.B. L/R/B/A :: ",4(1x,L1))', Rank_of_process, period
               ibufer(2*n)   = c_local_object_part(n_left(n))%segment_number
            END IF
         END DO
-        CALL MPI_SEND(ibufer(1:4), 4, MPI_INTEGER, Rank_of_master_left, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(ibufer(1:4), 4, MPI_INTEGER, Rank_of_master_left, Rank_of_process, MPI_COMM_WORLD, ierr) 
      END IF
 
      IF (connect_left) THEN
@@ -2177,7 +2176,7 @@ print '("Process ",i4," :: P.B. L/R/B/A :: ",4(1x,L1))', Rank_of_process, period
               ibufer(2*n)   = c_local_object_part(n_above(n))%segment_number
            END IF
         END DO
-        CALL MPI_SEND(ibufer(1:4), 4, MPI_INTEGER, Rank_of_master_above, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(ibufer(1:4), 4, MPI_INTEGER, Rank_of_master_above, Rank_of_process, MPI_COMM_WORLD, ierr) 
      END IF
 
      IF (connect_below) THEN
@@ -2189,7 +2188,7 @@ print '("Process ",i4," :: P.B. L/R/B/A :: ",4(1x,L1))', Rank_of_process, period
               ibufer(2*n)   = c_local_object_part(n_below(n))%segment_number
            END IF
         END DO
-        CALL MPI_SEND(ibufer(1:4), 4, MPI_INTEGER, Rank_of_master_below, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(ibufer(1:4), 4, MPI_INTEGER, Rank_of_master_below, Rank_of_process, MPI_COMM_WORLD, ierr) 
      END IF
 
      IF (connect_below) THEN
@@ -2284,7 +2283,7 @@ print '("Process ",i4," :: P.B. L/R/B/A :: ",4(1x,L1))', Rank_of_process, period
               ibufer(2*n)   = c_local_object_part(n_right(n))%segment_number
            END IF
         END DO
-        CALL MPI_SEND(ibufer(1:4), 4, MPI_INTEGER, Rank_of_master_right, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(ibufer(1:4), 4, MPI_INTEGER, Rank_of_master_right, Rank_of_process, MPI_COMM_WORLD, ierr) 
      END IF
 
      IF (connect_left) THEN
@@ -2296,7 +2295,7 @@ print '("Process ",i4," :: P.B. L/R/B/A :: ",4(1x,L1))', Rank_of_process, period
               ibufer(2*n)   = c_local_object_part(n_left(n))%segment_number
            END IF
         END DO
-        CALL MPI_SEND(ibufer(1:4), 4, MPI_INTEGER, Rank_of_master_left, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(ibufer(1:4), 4, MPI_INTEGER, Rank_of_master_left, Rank_of_process, MPI_COMM_WORLD, ierr) 
      END IF
 
      IF (connect_below) THEN
@@ -2348,7 +2347,7 @@ print '("Process ",i4," :: P.B. L/R/B/A :: ",4(1x,L1))', Rank_of_process, period
               ibufer(2*n)   = c_local_object_part(n_above(n))%segment_number
            END IF
         END DO
-        CALL MPI_SEND(ibufer(1:4), 4, MPI_INTEGER, Rank_of_master_above, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(ibufer(1:4), 4, MPI_INTEGER, Rank_of_master_above, Rank_of_process, MPI_COMM_WORLD, ierr) 
      END IF
 
      IF (connect_below) THEN
@@ -2360,7 +2359,7 @@ print '("Process ",i4," :: P.B. L/R/B/A :: ",4(1x,L1))', Rank_of_process, period
               ibufer(2*n)   = c_local_object_part(n_below(n))%segment_number
            END IF
         END DO
-        CALL MPI_SEND(ibufer(1:4), 4, MPI_INTEGER, Rank_of_master_below, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(ibufer(1:4), 4, MPI_INTEGER, Rank_of_master_below, Rank_of_process, MPI_COMM_WORLD, ierr) 
      END IF
 
   END IF
@@ -2546,9 +2545,9 @@ SUBROUTINE SET_COMMUNICATIONS
   USE CurrentProblemValues
   USE ClusterAndItsBoundaries
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER errcode,ierr
   INTEGER stattus(MPI_STATUS_SIZE)
@@ -2606,16 +2605,16 @@ SUBROUTINE SET_COMMUNICATIONS
 
         IF (Rank_of_master_right.GE.0) THEN
 ! ##  1 ## send right the number of levels ----------------------------------
-           CALL MPI_SEND(N_processes_cluster, 1, MPI_INTEGER, Rank_of_master_right, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+           CALL MPI_SEND(N_processes_cluster, 1, MPI_INTEGER, Rank_of_master_right, Rank_of_process, MPI_COMM_WORLD, ierr) 
 ! ##  2 ## send right the ranks
-           CALL MPI_SEND(horizontal_rank_in_cluster_level, N_processes_cluster, MPI_INTEGER, Rank_of_master_right, Rank_of_process+SHIFT1, MPI_COMM_WORLD, request, ierr)     
+           CALL MPI_SEND(horizontal_rank_in_cluster_level, N_processes_cluster, MPI_INTEGER, Rank_of_master_right, Rank_of_process+SHIFT1, MPI_COMM_WORLD, ierr)     
         END IF
 
         IF (Rank_of_master_left.GE.0) THEN
 ! ##  3 ## send left the number of levels
-           CALL MPI_SEND(N_processes_cluster, 1, MPI_INTEGER, Rank_of_master_left, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+           CALL MPI_SEND(N_processes_cluster, 1, MPI_INTEGER, Rank_of_master_left, Rank_of_process, MPI_COMM_WORLD, ierr) 
 ! ##  4 ## send left the ranks
-           CALL MPI_SEND(horizontal_rank_in_cluster_level, N_processes_cluster, MPI_INTEGER, Rank_of_master_left, Rank_of_process+SHIFT1, MPI_COMM_WORLD, request, ierr)     
+           CALL MPI_SEND(horizontal_rank_in_cluster_level, N_processes_cluster, MPI_INTEGER, Rank_of_master_left, Rank_of_process+SHIFT1, MPI_COMM_WORLD, ierr)     
         END IF
 
         IF (Rank_of_master_left.GE.0) THEN
@@ -2636,16 +2635,16 @@ SUBROUTINE SET_COMMUNICATIONS
 
         IF (Rank_of_master_above.GE.0) THEN
 ! ##  9 ## send up the number of levels -------------------------------------
-           CALL MPI_SEND(N_processes_cluster, 1, MPI_INTEGER, Rank_of_master_above, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+           CALL MPI_SEND(N_processes_cluster, 1, MPI_INTEGER, Rank_of_master_above, Rank_of_process, MPI_COMM_WORLD, ierr) 
 ! ## 10 ## send up the ranks
-           CALL MPI_SEND(horizontal_rank_in_cluster_level, N_processes_cluster, MPI_INTEGER, Rank_of_master_above, Rank_of_process+SHIFT1, MPI_COMM_WORLD, request, ierr)     
+           CALL MPI_SEND(horizontal_rank_in_cluster_level, N_processes_cluster, MPI_INTEGER, Rank_of_master_above, Rank_of_process+SHIFT1, MPI_COMM_WORLD, ierr)     
         END IF
 
         IF (Rank_of_master_below.GE.0) THEN
 ! ## 11 ## send down the number of levels
-           CALL MPI_SEND(N_processes_cluster, 1, MPI_INTEGER, Rank_of_master_below, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+           CALL MPI_SEND(N_processes_cluster, 1, MPI_INTEGER, Rank_of_master_below, Rank_of_process, MPI_COMM_WORLD, ierr) 
 ! ## 12 ## send down the ranks
-           CALL MPI_SEND(horizontal_rank_in_cluster_level, N_processes_cluster, MPI_INTEGER, Rank_of_master_below, Rank_of_process+SHIFT1, MPI_COMM_WORLD, request, ierr)     
+           CALL MPI_SEND(horizontal_rank_in_cluster_level, N_processes_cluster, MPI_INTEGER, Rank_of_master_below, Rank_of_process+SHIFT1, MPI_COMM_WORLD, ierr)     
         END IF
 
         IF (Rank_of_master_below.GE.0) THEN
@@ -2685,16 +2684,16 @@ SUBROUTINE SET_COMMUNICATIONS
 
         IF (Rank_of_master_right.GE.0) THEN
 ! ##  5 ## send right the number of levels ----------------------------------
-           CALL MPI_SEND(N_processes_cluster, 1, MPI_INTEGER, Rank_of_master_right, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+           CALL MPI_SEND(N_processes_cluster, 1, MPI_INTEGER, Rank_of_master_right, Rank_of_process, MPI_COMM_WORLD, ierr) 
 ! ##  6 ## send right the ranks
-           CALL MPI_SEND(horizontal_rank_in_cluster_level, N_processes_cluster, MPI_INTEGER, Rank_of_master_right, Rank_of_process+SHIFT1, MPI_COMM_WORLD, request, ierr)     
+           CALL MPI_SEND(horizontal_rank_in_cluster_level, N_processes_cluster, MPI_INTEGER, Rank_of_master_right, Rank_of_process+SHIFT1, MPI_COMM_WORLD, ierr)     
         END IF
 
         IF (Rank_of_master_left.GE.0) THEN
 ! ##  7 ## send left the number of levels
-           CALL MPI_SEND(N_processes_cluster, 1, MPI_INTEGER, Rank_of_master_left, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+           CALL MPI_SEND(N_processes_cluster, 1, MPI_INTEGER, Rank_of_master_left, Rank_of_process, MPI_COMM_WORLD, ierr) 
 ! ##  8 ## send left the ranks
-           CALL MPI_SEND(horizontal_rank_in_cluster_level, N_processes_cluster, MPI_INTEGER, Rank_of_master_left, Rank_of_process+SHIFT1, MPI_COMM_WORLD, request, ierr)     
+           CALL MPI_SEND(horizontal_rank_in_cluster_level, N_processes_cluster, MPI_INTEGER, Rank_of_master_left, Rank_of_process+SHIFT1, MPI_COMM_WORLD, ierr)     
         END IF
 
         IF (Rank_of_master_below.GE.0) THEN
@@ -2715,16 +2714,16 @@ SUBROUTINE SET_COMMUNICATIONS
 
         IF (Rank_of_master_above.GE.0) THEN
 ! ## 13 ## send up the number of levels -------------------------------------
-           CALL MPI_SEND(N_processes_cluster, 1, MPI_INTEGER, Rank_of_master_above, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+           CALL MPI_SEND(N_processes_cluster, 1, MPI_INTEGER, Rank_of_master_above, Rank_of_process, MPI_COMM_WORLD, ierr) 
 ! ## 14 ## send up the ranks
-           CALL MPI_SEND(horizontal_rank_in_cluster_level, N_processes_cluster, MPI_INTEGER, Rank_of_master_above, Rank_of_process+SHIFT1, MPI_COMM_WORLD, request, ierr)     
+           CALL MPI_SEND(horizontal_rank_in_cluster_level, N_processes_cluster, MPI_INTEGER, Rank_of_master_above, Rank_of_process+SHIFT1, MPI_COMM_WORLD, ierr)     
         END IF
 
         IF (Rank_of_master_below.GE.0) THEN
 ! ## 15 ## send down the number of levels
-           CALL MPI_SEND(N_processes_cluster, 1, MPI_INTEGER, Rank_of_master_below, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+           CALL MPI_SEND(N_processes_cluster, 1, MPI_INTEGER, Rank_of_master_below, Rank_of_process, MPI_COMM_WORLD, ierr) 
 ! ## 16 ## send down the ranks
-           CALL MPI_SEND(horizontal_rank_in_cluster_level, N_processes_cluster, MPI_INTEGER, Rank_of_master_below, Rank_of_process+SHIFT1, MPI_COMM_WORLD, request, ierr)     
+           CALL MPI_SEND(horizontal_rank_in_cluster_level, N_processes_cluster, MPI_INTEGER, Rank_of_master_below, Rank_of_process+SHIFT1, MPI_COMM_WORLD, ierr)     
         END IF
 
      END IF
@@ -2816,9 +2815,9 @@ SUBROUTINE COLLECT_MASTERS_INFO
   USE ParallelOperationValues
   USE LoadBalancing
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER ierr
 
@@ -2859,9 +2858,9 @@ SUBROUTINE DISTRIBUTE_CLUSTER_PARAMETERS
   USE IonParticles, ONLY : N_spec
   USE SetupValues
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER errcode,ierr
 
@@ -3159,10 +3158,9 @@ SUBROUTINE DISTRIBUTE_PARTICLES
   USE ClusterAndItsBoundaries
 
   USE rng_wrapper
+  use mpi
 
   IMPLICIT NONE
-
-  INCLUDE 'mpif.h'
 
   REAL(8) x_limit_left, x_limit_right
   REAL(8) y_limit_bot, y_limit_top

--- a/src/pic2d_Diagnostics.f90
+++ b/src/pic2d_Diagnostics.f90
@@ -325,9 +325,9 @@ subroutine report_total_number_of_particles
   USE ElectronParticles, ONLY : N_electrons, electron
   USE IonParticles, ONLY : N_spec, N_ions, ion, Ms
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER ierr
   INTEGER stattus(MPI_STATUS_SIZE)

--- a/src/pic2d_ElectricFieldCalc_FFT_X.f90
+++ b/src/pic2d_ElectricFieldCalc_FFT_X.f90
@@ -10,9 +10,9 @@ SUBROUTINE SOLVE_POISSON_FFTX_LINSYSY
   USE Diagnostics, ONLY : Save_probes_e_data_T_cntr, N_of_probes_cluster, List_of_probes_cluster, Probe_position, probe_F_cluster
   USE SetupValues, ONLY : ht_soft_grid_requested, ht_grid_requested, grid_j, F_grid
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER ierr
   INTEGER stattus(MPI_STATUS_SIZE)
@@ -186,7 +186,7 @@ character(10) myfilename ! A_NNNN.dat
               rbufer(pos1:pos2) = c_rho(indx_x_begin:indx_x_end, j)
            END DO
 
-           CALL MPI_SEND(rbufer(1:bufsize), bufsize, MPI_DOUBLE_PRECISION, comm_FFTX_step(k)%rank, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+           CALL MPI_SEND(rbufer(1:bufsize), bufsize, MPI_DOUBLE_PRECISION, comm_FFTX_step(k)%rank, Rank_of_process, MPI_COMM_WORLD, ierr) 
 
 ! receive
            indx_x_begin = comm_FFTX_step(k)%c_indx_x_min+1
@@ -231,7 +231,7 @@ character(10) myfilename ! A_NNNN.dat
               rbufer(pos1:pos2) = c_rho(indx_x_begin:indx_x_end, j)
            END DO
 
-           CALL MPI_SEND(rbufer(1:bufsize), bufsize, MPI_DOUBLE_PRECISION, comm_FFTX_step(k)%rank, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+           CALL MPI_SEND(rbufer(1:bufsize), bufsize, MPI_DOUBLE_PRECISION, comm_FFTX_step(k)%rank, Rank_of_process, MPI_COMM_WORLD, ierr) 
 
 
         END IF
@@ -264,7 +264,7 @@ character(10) myfilename ! A_NNNN.dat
            pos2 = pos2 + global_maximal_i - 1
            rbufer(pos1:pos2) = xband(0:global_maximal_i-2, j)
         END DO
-        CALL MPI_SEND(rbufer(1:bufsize), bufsize, MPI_DOUBLE_PRECISION, field_calculator(k)%rank, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(rbufer(1:bufsize), bufsize, MPI_DOUBLE_PRECISION, field_calculator(k)%rank, Rank_of_process, MPI_COMM_WORLD, ierr) 
      END DO
 
   ELSE
@@ -364,7 +364,7 @@ character(10) myfilename ! A_NNNN.dat
         rbufer(pos1:pos2) = xband(0:global_maximal_i, j)
      END DO
         
-     CALL MPI_SEND(rbufer(1:bufsize), bufsize, MPI_DOUBLE_PRECISION, field_master, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+     CALL MPI_SEND(rbufer(1:bufsize), bufsize, MPI_DOUBLE_PRECISION, field_master, Rank_of_process, MPI_COMM_WORLD, ierr) 
 
   END IF
 
@@ -405,7 +405,7 @@ character(10) myfilename ! A_NNNN.dat
               rbufer(pos1:pos2) = xband(indx_x_begin:indx_x_end, j)
            END DO
 
-           CALL MPI_SEND(rbufer(1:bufsize), bufsize, MPI_DOUBLE_PRECISION, comm_FFTX_step(k)%rank, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+           CALL MPI_SEND(rbufer(1:bufsize), bufsize, MPI_DOUBLE_PRECISION, comm_FFTX_step(k)%rank, Rank_of_process, MPI_COMM_WORLD, ierr) 
 
 ! receive
            indx_x_begin = c_indx_x_min
@@ -457,7 +457,7 @@ character(10) myfilename ! A_NNNN.dat
               rbufer(pos1:pos2) = xband(indx_x_begin:indx_x_end, j)
            END DO
 
-           CALL MPI_SEND(rbufer, bufsize, MPI_DOUBLE_PRECISION, comm_FFTX_step(k)%rank, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+           CALL MPI_SEND(rbufer, bufsize, MPI_DOUBLE_PRECISION, comm_FFTX_step(k)%rank, Rank_of_process, MPI_COMM_WORLD, ierr) 
 
         END IF
 
@@ -540,7 +540,7 @@ character(10) myfilename ! A_NNNN.dat
               END DO
            END DO
 
-           CALL MPI_SEND(rbufer(1:bufsize), bufsize, MPI_DOUBLE_PRECISION, comm_SYSY_step(k)%rank, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+           CALL MPI_SEND(rbufer(1:bufsize), bufsize, MPI_DOUBLE_PRECISION, comm_SYSY_step(k)%rank, Rank_of_process, MPI_COMM_WORLD, ierr) 
 ! receive
            IF (comm_SYSY_step(k)%c_indx_y_min.GT.0) THEN
               indx_y_begin = comm_SYSY_step(k)%c_indx_y_min+1
@@ -623,7 +623,7 @@ character(10) myfilename ! A_NNNN.dat
               END DO
            END DO
 
-           CALL MPI_SEND(rbufer(1:bufsize), bufsize, MPI_DOUBLE_PRECISION, comm_SYSY_step(k)%rank, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+           CALL MPI_SEND(rbufer(1:bufsize), bufsize, MPI_DOUBLE_PRECISION, comm_SYSY_step(k)%rank, Rank_of_process, MPI_COMM_WORLD, ierr) 
 
         END IF
 
@@ -652,7 +652,7 @@ character(10) myfilename ! A_NNNN.dat
            pos2 = pos2 + ysize
            rbufer(pos1:pos2) = yband(0:(ysize-1), n)
         END DO
-        CALL MPI_SEND(rbufer(1:bufsize), bufsize, MPI_DOUBLE_PRECISION, field_calculator(k)%rank, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(rbufer(1:bufsize), bufsize, MPI_DOUBLE_PRECISION, field_calculator(k)%rank, Rank_of_process, MPI_COMM_WORLD, ierr) 
      END DO
 
   ELSE
@@ -788,7 +788,7 @@ character(10) myfilename ! A_NNNN.dat
         pos2 = pos2 + ysize
         rbufer(pos1:pos2) = yband(0:(ysize-1), n)
      END DO
-     CALL MPI_SEND(rbufer(1:bufsize), bufsize, MPI_DOUBLE_PRECISION, field_master, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+     CALL MPI_SEND(rbufer(1:bufsize), bufsize, MPI_DOUBLE_PRECISION, field_master, Rank_of_process, MPI_COMM_WORLD, ierr) 
 
   END IF
 
@@ -850,7 +850,7 @@ character(10) myfilename ! A_NNNN.dat
               rbufer(pos1:pos2) = yband(indx_y_begin:indx_y_end, n)
            END DO
 
-           CALL MPI_SEND(rbufer(1:bufsize), bufsize, MPI_DOUBLE_PRECISION, comm_SYSY_step(k)%rank, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+           CALL MPI_SEND(rbufer(1:bufsize), bufsize, MPI_DOUBLE_PRECISION, comm_SYSY_step(k)%rank, Rank_of_process, MPI_COMM_WORLD, ierr) 
 
 ! receive
            indx_y_begin = c_indx_y_min !MAX(c_indx_y_min, 1) 
@@ -910,7 +910,7 @@ character(10) myfilename ! A_NNNN.dat
               rbufer(pos1:pos2) = yband(indx_y_begin:indx_y_end, n)
            END DO
 
-           CALL MPI_SEND(rbufer(1:bufsize), bufsize, MPI_DOUBLE_PRECISION, comm_SYSY_step(k)%rank, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+           CALL MPI_SEND(rbufer(1:bufsize), bufsize, MPI_DOUBLE_PRECISION, comm_SYSY_step(k)%rank, Rank_of_process, MPI_COMM_WORLD, ierr) 
 
         END IF
 
@@ -984,7 +984,7 @@ character(10) myfilename ! A_NNNN.dat
               rbufer(pos1:pos2) = c_phi(indx_x_begin:indx_x_end, j)
            END DO
 
-           CALL MPI_SEND(rbufer(1:bufsize), bufsize, MPI_DOUBLE_PRECISION, comm_FFTX_step(k)%rank, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+           CALL MPI_SEND(rbufer(1:bufsize), bufsize, MPI_DOUBLE_PRECISION, comm_FFTX_step(k)%rank, Rank_of_process, MPI_COMM_WORLD, ierr) 
 
 ! receive
            indx_x_begin = comm_FFTX_step(k)%c_indx_x_min
@@ -1035,7 +1035,7 @@ character(10) myfilename ! A_NNNN.dat
               rbufer(pos1:pos2) = c_phi(indx_x_begin:indx_x_end, j)
            END DO
 
-           CALL MPI_SEND(rbufer(1:bufsize), bufsize, MPI_DOUBLE_PRECISION, comm_FFTX_step(k)%rank, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+           CALL MPI_SEND(rbufer(1:bufsize), bufsize, MPI_DOUBLE_PRECISION, comm_FFTX_step(k)%rank, Rank_of_process, MPI_COMM_WORLD, ierr) 
 
         END IF
 
@@ -1073,7 +1073,7 @@ character(10) myfilename ! A_NNNN.dat
            rbufer(pos1:pos2) = xband(0:global_maximal_i, j)
         END DO
 
-        CALL MPI_SEND(rbufer(1:bufsize), bufsize, MPI_DOUBLE_PRECISION, field_calculator(k)%rank, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(rbufer(1:bufsize), bufsize, MPI_DOUBLE_PRECISION, field_calculator(k)%rank, Rank_of_process, MPI_COMM_WORLD, ierr) 
 
      END DO
 
@@ -1166,7 +1166,7 @@ character(10) myfilename ! A_NNNN.dat
         rbufer(pos1:pos2) = xband(0:global_maximal_i, j)
      END DO
         
-     CALL MPI_SEND(rbufer(1:bufsize), bufsize, MPI_DOUBLE_PRECISION, field_master, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+     CALL MPI_SEND(rbufer(1:bufsize), bufsize, MPI_DOUBLE_PRECISION, field_master, Rank_of_process, MPI_COMM_WORLD, ierr) 
 
   END IF
 
@@ -1202,7 +1202,7 @@ character(10) myfilename ! A_NNNN.dat
               rbufer(pos1:pos2) = xband(indx_x_begin:indx_x_end, j)
            END DO
 
-           CALL MPI_SEND(rbufer(1:bufsize), bufsize, MPI_DOUBLE_PRECISION, comm_FFTX_step(k)%rank, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+           CALL MPI_SEND(rbufer(1:bufsize), bufsize, MPI_DOUBLE_PRECISION, comm_FFTX_step(k)%rank, Rank_of_process, MPI_COMM_WORLD, ierr) 
 
 ! receive
            indx_x_begin = c_indx_x_min
@@ -1249,7 +1249,7 @@ character(10) myfilename ! A_NNNN.dat
               rbufer(pos1:pos2) = xband(indx_x_begin:indx_x_end, j)
            END DO
 
-           CALL MPI_SEND(rbufer(1:bufsize), bufsize, MPI_DOUBLE_PRECISION, comm_FFTX_step(k)%rank, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+           CALL MPI_SEND(rbufer(1:bufsize), bufsize, MPI_DOUBLE_PRECISION, comm_FFTX_step(k)%rank, Rank_of_process, MPI_COMM_WORLD, ierr) 
 
         END IF
 
@@ -1328,9 +1328,9 @@ SUBROUTINE CALCULATE_ELECTRIC_FIELD_FFTX_LINSYSY
   USE BlockAndItsBoundaries
   USE ClusterAndItsBoundaries
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER ierr
   INTEGER stattus(MPI_STATUS_SIZE)
@@ -1393,14 +1393,14 @@ SUBROUTINE CALCULATE_ELECTRIC_FIELD_FFTX_LINSYSY
 ! ## 1 ## send right electric fields in column left of the right edge
            rbufer(1:n1)           = EX(c_indx_x_max-1, c_indx_y_min:c_indx_y_max)
            rbufer((n1+1):(n1+n1)) = EY(c_indx_x_max-1, c_indx_y_min:c_indx_y_max)
-           CALL MPI_SEND(rbufer, n1+n1, MPI_DOUBLE_PRECISION, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, n1+n1, MPI_DOUBLE_PRECISION, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
         IF (Rank_horizontal_left.GE.0) THEN
 ! ## 2 ## send left electric field in column right of the left edge
            rbufer(1:n1)           = EX(c_indx_x_min+1, c_indx_y_min:c_indx_y_max)
            rbufer((n1+1):(n1+n1)) = EY(c_indx_x_min+1, c_indx_y_min:c_indx_y_max)
-           CALL MPI_SEND(rbufer, n1+n1, MPI_DOUBLE_PRECISION, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, n1+n1, MPI_DOUBLE_PRECISION, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
         IF (Rank_horizontal_left.GE.0) THEN
@@ -1424,14 +1424,14 @@ SUBROUTINE CALCULATE_ELECTRIC_FIELD_FFTX_LINSYSY
 ! ## 5 ## send up electric fields in the row below the top edge
            rbufer(1:n3)           = EX(c_indx_x_min:c_indx_x_max, c_indx_y_max-1)
            rbufer((n3+1):(n3+n3)) = EY(c_indx_x_min:c_indx_x_max, c_indx_y_max-1)
-           CALL MPI_SEND(rbufer, n3+n3, MPI_DOUBLE_PRECISION, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, n3+n3, MPI_DOUBLE_PRECISION, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
         IF (Rank_horizontal_below.GE.0) THEN
 ! ## 6 ## send down electric fields in the row above the bottom edge
            rbufer(1:n3)           = EX(c_indx_x_min:c_indx_x_max, c_indx_y_min+1)
            rbufer((n3+1):(n3+n3)) = EY(c_indx_x_min:c_indx_x_max, c_indx_y_min+1)
-           CALL MPI_SEND(rbufer, n3+n3, MPI_DOUBLE_PRECISION, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, n3+n3, MPI_DOUBLE_PRECISION, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
         IF (Rank_horizontal_below.GE.0) THEN
@@ -1472,14 +1472,14 @@ SUBROUTINE CALCULATE_ELECTRIC_FIELD_FFTX_LINSYSY
 ! ## 3 ## send right electric fields in column left of the right edge
            rbufer(1:n1)           = EX(c_indx_x_max-1, c_indx_y_min:c_indx_y_max)
            rbufer((n1+1):(n1+n1)) = EY(c_indx_x_max-1, c_indx_y_min:c_indx_y_max)
-           CALL MPI_SEND(rbufer, n1+n1, MPI_DOUBLE_PRECISION, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, n1+n1, MPI_DOUBLE_PRECISION, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
         IF (Rank_horizontal_left.GE.0) THEN
 ! ## 4 ## send left electric field in column right of the left edge
            rbufer(1:n1)           = EX(c_indx_x_min+1, c_indx_y_min:c_indx_y_max)
            rbufer((n1+1):(n1+n1)) = EY(c_indx_x_min+1, c_indx_y_min:c_indx_y_max)
-           CALL MPI_SEND(rbufer, n1+n1, MPI_DOUBLE_PRECISION, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, n1+n1, MPI_DOUBLE_PRECISION, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
      
         IF (ALLOCATED(rbufer)) DEALLOCATE(rbufer, STAT=ALLOC_ERR)
@@ -1503,14 +1503,14 @@ SUBROUTINE CALCULATE_ELECTRIC_FIELD_FFTX_LINSYSY
 ! ## 7 ## send up electric fields in the row below the top edge
            rbufer(1:n3)           = EX(c_indx_x_min:c_indx_x_max, c_indx_y_max-1)
            rbufer((n3+1):(n3+n3)) = EY(c_indx_x_min:c_indx_x_max, c_indx_y_max-1)
-           CALL MPI_SEND(rbufer, n3+n3, MPI_DOUBLE_PRECISION, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, n3+n3, MPI_DOUBLE_PRECISION, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
         IF (Rank_horizontal_below.GE.0) THEN
 ! ## 8 ## send down electric fields in the row above the bottom edge
            rbufer(1:n3)           = EX(c_indx_x_min:c_indx_x_max, c_indx_y_min+1)
            rbufer((n3+1):(n3+n3)) = EY(c_indx_x_min:c_indx_x_max, c_indx_y_min+1)
-           CALL MPI_SEND(rbufer, n3+n3, MPI_DOUBLE_PRECISION, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, n3+n3, MPI_DOUBLE_PRECISION, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
      END IF

--- a/src/pic2d_ElectricFieldCalc_PETSc.F90
+++ b/src/pic2d_ElectricFieldCalc_PETSc.F90
@@ -12,9 +12,10 @@ SUBROUTINE SOLVE_POTENTIAL_WITH_PETSC
   USE BlockAndItsBoundaries
   USE Diagnostics, ONLY : Save_probes_e_data_T_cntr, N_of_probes_block, Probe_params_block_list, probe_F_block
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
   INTEGER stattus(MPI_STATUS_SIZE)
@@ -231,13 +232,13 @@ SUBROUTINE SOLVE_POTENTIAL_WITH_PETSC
      IF (Rank_of_process_right.GE.0) THEN
 ! ## 1 ## send right potential in column left of the right edge
         rbufer(1:n1) = phi(indx_x_max-1, indx_y_min:indx_y_max)
-        CALL MPI_SEND(rbufer, n1, MPI_DOUBLE_PRECISION, Rank_of_process_right, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(rbufer, n1, MPI_DOUBLE_PRECISION, Rank_of_process_right, Rank_of_process, MPI_COMM_WORLD, ierr) 
      END IF
 
      IF (Rank_of_process_left.GE.0) THEN
 ! ## 2 ## send left potential in column right of the left edge
         rbufer(1:n1) = phi(indx_x_min+1, indx_y_min:indx_y_max)
-        CALL MPI_SEND(rbufer, n1, MPI_DOUBLE_PRECISION, Rank_of_process_left, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(rbufer, n1, MPI_DOUBLE_PRECISION, Rank_of_process_left, Rank_of_process, MPI_COMM_WORLD, ierr) 
      END IF
 
      IF (Rank_of_process_left.GE.0) THEN
@@ -258,13 +259,13 @@ SUBROUTINE SOLVE_POTENTIAL_WITH_PETSC
      IF (Rank_of_process_above.GE.0) THEN
 ! ## 5 ## send up potential in the row below the top edge
         rbufer(1:n3) = phi(indx_x_min:indx_x_max, indx_y_max-1)
-        CALL MPI_SEND(rbufer, n3, MPI_DOUBLE_PRECISION, Rank_of_process_above, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(rbufer, n3, MPI_DOUBLE_PRECISION, Rank_of_process_above, Rank_of_process, MPI_COMM_WORLD, ierr) 
      END IF
 
      IF (Rank_of_process_below.GE.0) THEN
 ! ## 6 ## send down potential in the row above the bottom edge
         rbufer(1:n3) = phi(indx_x_min:indx_x_max, indx_y_min+1)
-        CALL MPI_SEND(rbufer, n3, MPI_DOUBLE_PRECISION, Rank_of_process_below, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(rbufer, n3, MPI_DOUBLE_PRECISION, Rank_of_process_below, Rank_of_process, MPI_COMM_WORLD, ierr) 
      END IF
 
      IF (Rank_of_process_below.GE.0) THEN
@@ -300,13 +301,13 @@ SUBROUTINE SOLVE_POTENTIAL_WITH_PETSC
      IF (Rank_of_process_right.GE.0) THEN
 ! ## 3 ## send right potential in column left of the right edge
         rbufer(1:n1) = phi(indx_x_max-1, indx_y_min:indx_y_max)
-        CALL MPI_SEND(rbufer, n1, MPI_DOUBLE_PRECISION, Rank_of_process_right, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(rbufer, n1, MPI_DOUBLE_PRECISION, Rank_of_process_right, Rank_of_process, MPI_COMM_WORLD, ierr) 
      END IF
 
      IF (Rank_of_process_left.GE.0) THEN
 ! ## 4 ## send left potential in column right of the left edge
         rbufer(1:n1) = phi(indx_x_min+1, indx_y_min:indx_y_max)
-        CALL MPI_SEND(rbufer, n1, MPI_DOUBLE_PRECISION, Rank_of_process_left, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(rbufer, n1, MPI_DOUBLE_PRECISION, Rank_of_process_left, Rank_of_process, MPI_COMM_WORLD, ierr) 
      END IF
 
      IF (ALLOCATED(rbufer)) DEALLOCATE(rbufer, STAT=ALLOC_ERR)
@@ -327,13 +328,13 @@ SUBROUTINE SOLVE_POTENTIAL_WITH_PETSC
      IF (Rank_of_process_above.GE.0) THEN
 ! ## 7 ## send up potential in the row below the top edge
         rbufer(1:n3) = phi(indx_x_min:indx_x_max, indx_y_max-1)
-        CALL MPI_SEND(rbufer, n3, MPI_DOUBLE_PRECISION, Rank_of_process_above, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(rbufer, n3, MPI_DOUBLE_PRECISION, Rank_of_process_above, Rank_of_process, MPI_COMM_WORLD, ierr) 
      END IF
 
      IF (Rank_of_process_below.GE.0) THEN
 ! ## 8 ## send down potential in the row above the bottom edge
         rbufer(1:n3) = phi(indx_x_min:indx_x_max, indx_y_min+1)
-        CALL MPI_SEND(rbufer, n3, MPI_DOUBLE_PRECISION, Rank_of_process_below, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(rbufer, n3, MPI_DOUBLE_PRECISION, Rank_of_process_below, Rank_of_process, MPI_COMM_WORLD, ierr) 
      END IF
 
   END IF
@@ -365,9 +366,10 @@ SUBROUTINE CALCULATE_ELECTRIC_FIELD
   USE BlockAndItsBoundaries
   USE ClusterAndItsBoundaries
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER ierr
   INTEGER stattus(MPI_STATUS_SIZE)
@@ -555,14 +557,14 @@ SUBROUTINE CALCULATE_ELECTRIC_FIELD
 ! ## 1 ## send right electric fields in column left of the right edge
            rbufer(1:n1)           = EX(c_indx_x_max-1, c_indx_y_min:c_indx_y_max)
            rbufer((n1+1):(n1+n1)) = EY(c_indx_x_max-1, c_indx_y_min:c_indx_y_max)
-           CALL MPI_SEND(rbufer, n1+n1, MPI_DOUBLE_PRECISION, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, n1+n1, MPI_DOUBLE_PRECISION, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
         IF (Rank_horizontal_left.GE.0) THEN
 ! ## 2 ## send left electric field in column right of the left edge
            rbufer(1:n1)           = EX(c_indx_x_min+1, c_indx_y_min:c_indx_y_max)
            rbufer((n1+1):(n1+n1)) = EY(c_indx_x_min+1, c_indx_y_min:c_indx_y_max)
-           CALL MPI_SEND(rbufer, n1+n1, MPI_DOUBLE_PRECISION, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, n1+n1, MPI_DOUBLE_PRECISION, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
         IF (Rank_horizontal_left.GE.0) THEN
@@ -586,14 +588,14 @@ SUBROUTINE CALCULATE_ELECTRIC_FIELD
 ! ## 5 ## send up electric fields in the row below the top edge
            rbufer(1:n3)           = EX(c_indx_x_min:c_indx_x_max, c_indx_y_max-1)
            rbufer((n3+1):(n3+n3)) = EY(c_indx_x_min:c_indx_x_max, c_indx_y_max-1)
-           CALL MPI_SEND(rbufer, n3+n3, MPI_DOUBLE_PRECISION, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, n3+n3, MPI_DOUBLE_PRECISION, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
         IF (Rank_horizontal_below.GE.0) THEN
 ! ## 6 ## send down electric fields in the row above the bottom edge
            rbufer(1:n3)           = EX(c_indx_x_min:c_indx_x_max, c_indx_y_min+1)
            rbufer((n3+1):(n3+n3)) = EY(c_indx_x_min:c_indx_x_max, c_indx_y_min+1)
-           CALL MPI_SEND(rbufer, n3+n3, MPI_DOUBLE_PRECISION, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, n3+n3, MPI_DOUBLE_PRECISION, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
         IF (Rank_horizontal_below.GE.0) THEN
@@ -634,14 +636,14 @@ SUBROUTINE CALCULATE_ELECTRIC_FIELD
 ! ## 3 ## send right electric fields in column left of the right edge
            rbufer(1:n1)           = EX(c_indx_x_max-1, c_indx_y_min:c_indx_y_max)
            rbufer((n1+1):(n1+n1)) = EY(c_indx_x_max-1, c_indx_y_min:c_indx_y_max)
-           CALL MPI_SEND(rbufer, n1+n1, MPI_DOUBLE_PRECISION, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, n1+n1, MPI_DOUBLE_PRECISION, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
         IF (Rank_horizontal_left.GE.0) THEN
 ! ## 4 ## send left electric field in column right of the left edge
            rbufer(1:n1)           = EX(c_indx_x_min+1, c_indx_y_min:c_indx_y_max)
            rbufer((n1+1):(n1+n1)) = EY(c_indx_x_min+1, c_indx_y_min:c_indx_y_max)
-           CALL MPI_SEND(rbufer, n1+n1, MPI_DOUBLE_PRECISION, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, n1+n1, MPI_DOUBLE_PRECISION, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
         IF (ALLOCATED(rbufer)) DEALLOCATE(rbufer, STAT=ALLOC_ERR)
@@ -665,14 +667,14 @@ SUBROUTINE CALCULATE_ELECTRIC_FIELD
 ! ## 7 ## send up electric fields in the row below the top edge
            rbufer(1:n3)           = EX(c_indx_x_min:c_indx_x_max, c_indx_y_max-1)
            rbufer((n3+1):(n3+n3)) = EY(c_indx_x_min:c_indx_x_max, c_indx_y_max-1)
-           CALL MPI_SEND(rbufer, n3+n3, MPI_DOUBLE_PRECISION, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, n3+n3, MPI_DOUBLE_PRECISION, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
         IF (Rank_horizontal_below.GE.0) THEN
 ! ## 8 ## send down electric fields in the row above the bottom edge
            rbufer(1:n3)           = EX(c_indx_x_min:c_indx_x_max, c_indx_y_min+1)
            rbufer((n3+1):(n3+n3)) = EY(c_indx_x_min:c_indx_x_max, c_indx_y_min+1)
-           CALL MPI_SEND(rbufer, n3+n3, MPI_DOUBLE_PRECISION, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, n3+n3, MPI_DOUBLE_PRECISION, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
      END IF
@@ -772,7 +774,7 @@ SUBROUTINE CALCULATE_ELECTRIC_FIELD
         pos1 = pos2 + 1
         pos2 = pos2 + indx_x_max - indx_x_min + 1
      END DO
-     CALL MPI_SEND(rbufer, bufsize, MPI_DOUBLE_PRECISION, field_master, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+     CALL MPI_SEND(rbufer, bufsize, MPI_DOUBLE_PRECISION, field_master, Rank_of_process, MPI_COMM_WORLD, ierr) 
     
      DEALLOCATE(loc_EX, STAT=ALLOC_ERR)
      DEALLOCATE(loc_EY, STAT=ALLOC_ERR)
@@ -811,6 +813,8 @@ SUBROUTINE CLEAR_ACCUMULATED_FIELDS
 
   USE CurrentProblemValues
   USE ClusterAndItsBoundaries
+
+  use mpi
 
   IMPLICIT NONE
 

--- a/src/pic2d_ElectronDynamics.f90
+++ b/src/pic2d_ElectronDynamics.f90
@@ -7,9 +7,10 @@ SUBROUTINE ADVANCE_ELECTRONS
   USE ElectronParticles
   USE ClusterAndItsBoundaries
   
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
 
@@ -525,9 +526,10 @@ SUBROUTINE REMOVE_ELECTRON(k)
   USE ParallelOperationValues
   USE ElectronParticles
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
 
@@ -568,6 +570,8 @@ SUBROUTINE ADD_ELECTRON_TO_SEND_LEFT(x, y, vx, vy, vz, tag)
 
 !use CurrentProblemValues, only : T_cntr
 !USE ParallelOperationValues, only : Rank_of_process
+
+  use mpi
 
   IMPLICIT NONE
 
@@ -640,6 +644,8 @@ SUBROUTINE ADD_ELECTRON_TO_SEND_RIGHT(x, y, vx, vy, vz, tag)
 
 !use CurrentProblemValues, only : T_cntr
 !USE ParallelOperationValues, only : Rank_of_process
+
+  use mpi
 
   IMPLICIT NONE
 
@@ -714,6 +720,8 @@ SUBROUTINE ADD_ELECTRON_TO_SEND_ABOVE(x, y, vx, vy, vz, tag)
 !use CurrentProblemValues, only : T_cntr
 !USE ParallelOperationValues, only : Rank_of_process
 
+  use mpi
+
   IMPLICIT NONE
 
   REAL(8) x, y, vx, vy, vz
@@ -786,6 +794,8 @@ SUBROUTINE ADD_ELECTRON_TO_SEND_BELOW(x, y, vx, vy, vz, tag)
 !use CurrentProblemValues, only : T_cntr
 !USE ParallelOperationValues, only : Rank_of_process
 
+  use mpi
+
   IMPLICIT NONE
 
   REAL(8) x, y, vx, vy, vz
@@ -856,6 +866,8 @@ SUBROUTINE ADD_ELECTRON_TO_ADD_LIST(x, y, vx, vy, vz, tag)
   USE ElectronParticles, ONLY : N_e_to_add, max_N_e_to_add, electron_to_add
 !  USE ParallelOperationValues
 
+  use mpi
+
   IMPLICIT NONE
 
   REAL(8) x, y, vx, vy, vz
@@ -922,9 +934,10 @@ SUBROUTINE REMOVE_ELECTRON_FROM_ADD_LIST(k)
   USE ParallelOperationValues
   USE ElectronParticles
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
 
@@ -971,9 +984,10 @@ SUBROUTINE FIND_ALIENS_IN_ELECTRON_ADD_LIST
   USE ClusterAndItsBoundaries
   USE ElectronParticles, ONLY : N_e_to_add, electron_to_add
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
 
@@ -1424,6 +1438,8 @@ SUBROUTINE FIND_INNER_OBJECT_COLL_IN_ELECTRON_ADD_LIST
   USE CurrentProblemValues
   USE ElectronParticles, ONLY : N_e_to_add, electron_to_add
 
+  use mpi
+
   IMPLICIT NONE
 
   INTEGER k, n 
@@ -1464,6 +1480,8 @@ SUBROUTINE PROCESS_ADDED_ELECTRONS
   USE ElectronParticles, ONLY : N_e_to_add, N_electrons, max_N_electrons, electron, electron_to_add
 
   USE rng_wrapper  !###???
+
+  use mpi
 
   IMPLICIT NONE
 
@@ -1571,9 +1589,10 @@ SUBROUTINE GATHER_ELECTRON_CHARGE_DENSITY
   USE BlockAndItsBoundaries, ONLY : indx_x_min, indx_x_max, indx_y_min, indx_y_max
 !  USE Diagnostics
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
   INTEGER stattus(MPI_STATUS_SIZE)
@@ -1707,13 +1726,13 @@ end if
         IF (Rank_horizontal_right.GE.0) THEN
 ! ## 1 ## send right densities in the right edge
            rbufer(1:n1) = c_rho(c_indx_x_max, c_indx_y_min:c_indx_y_max)
-           CALL MPI_SEND(rbufer, n1, MPI_DOUBLE_PRECISION, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, n1, MPI_DOUBLE_PRECISION, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
         IF (Rank_horizontal_left.GE.0) THEN
 ! ## 2 ## send left densities in the left edge
            rbufer(1:n1) = c_rho(c_indx_x_min, c_indx_y_min:c_indx_y_max)
-           CALL MPI_SEND(rbufer, n1, MPI_DOUBLE_PRECISION, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, n1, MPI_DOUBLE_PRECISION, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
         IF (Rank_horizontal_left.GE.0) THEN
@@ -1738,13 +1757,13 @@ end if
         IF (Rank_horizontal_above.GE.0) THEN
 ! ## 5 ## send up densities in the top edge
            rbufer(1:n3) = c_rho(c_indx_x_min:c_indx_x_max, c_indx_y_max)
-           CALL MPI_SEND(rbufer, n3, MPI_DOUBLE_PRECISION, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, n3, MPI_DOUBLE_PRECISION, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
         IF (Rank_horizontal_below.GE.0) THEN
 ! ## 6 ## send down densities in the bottom edge
            rbufer(1:n3) = c_rho(c_indx_x_min:c_indx_x_max, c_indx_y_min)
-           CALL MPI_SEND(rbufer, n3, MPI_DOUBLE_PRECISION, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, n3, MPI_DOUBLE_PRECISION, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
         IF (Rank_horizontal_below.GE.0) THEN
@@ -1788,13 +1807,13 @@ end if
         IF (Rank_horizontal_right.GE.0) THEN
 ! ## 3 ## send right densities in the right edge
            rbufer(1:n1) = c_rho(c_indx_x_max, c_indx_y_min:c_indx_y_max)
-           CALL MPI_SEND(rbufer, n1, MPI_DOUBLE_PRECISION, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, n1, MPI_DOUBLE_PRECISION, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
         IF (Rank_horizontal_left.GE.0) THEN
 ! ## 4 ## send left densities in the left edge
            rbufer(1:n1) = c_rho(c_indx_x_min, c_indx_y_min:c_indx_y_max)
-           CALL MPI_SEND(rbufer, n1, MPI_DOUBLE_PRECISION, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, n1, MPI_DOUBLE_PRECISION, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
         IF (ALLOCATED(rbufer)) DEALLOCATE(rbufer, STAT=ALLOC_ERR)
@@ -1819,13 +1838,13 @@ end if
         IF (Rank_horizontal_above.GE.0) THEN
 ! ## 7 ## send up densities in the top edge
            rbufer(1:n3) = c_rho(c_indx_x_min:c_indx_x_max, c_indx_y_max)
-           CALL MPI_SEND(rbufer, n3, MPI_DOUBLE_PRECISION, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, n3, MPI_DOUBLE_PRECISION, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
         IF (Rank_horizontal_below.GE.0) THEN
 ! ## 8 ## send down densities in the bottom edge
            rbufer(1:n3) = c_rho(c_indx_x_min:c_indx_x_max, c_indx_y_min)
-           CALL MPI_SEND(rbufer, n3, MPI_DOUBLE_PRECISION, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, n3, MPI_DOUBLE_PRECISION, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
      END IF
@@ -1948,7 +1967,7 @@ end if
 
               END DO
            END DO
-           CALL MPI_SEND(rbufer, bufsize, MPI_DOUBLE_PRECISION, field_calculator(k)%rank, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+           CALL MPI_SEND(rbufer, bufsize, MPI_DOUBLE_PRECISION, field_calculator(k)%rank, Rank_of_process, MPI_COMM_WORLD, ierr) 
         END DO
 
 ! cluster master is a field calaculator too, prepare its own charge density

--- a/src/pic2d_ElectronDynamicsWithVDFMoments.f90
+++ b/src/pic2d_ElectronDynamicsWithVDFMoments.f90
@@ -9,6 +9,8 @@ SUBROUTINE ADVANCE_ELECTRONS_PLUS
   USE ClusterAndItsBoundaries, ONLY : c_indx_x_min, c_indx_x_max, c_indx_y_min, c_indx_y_max
   USE Diagnostics, ONLY : Save_probes_e_data_T_cntr
 
+  use mpi
+
   IMPLICIT NONE
 
   LOGICAL collect_electron_moments_now
@@ -165,9 +167,10 @@ SUBROUTINE ADVANCE_ELECTRONS_AND_CALCULATE_MOMENTS_2D
   USE Diagnostics
 !------------------------------------------<<<
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
   INTEGER stattus(MPI_STATUS_SIZE)
@@ -1024,9 +1027,10 @@ SUBROUTINE ADVANCE_ELECTRONS_AND_CALCULATE_MOMENTS_PROBES
 
   USE Diagnostics
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
 

--- a/src/pic2d_ElectronExchange.f90
+++ b/src/pic2d_ElectronExchange.f90
@@ -6,9 +6,9 @@ SUBROUTINE EXCHANGE_ELECTRONS_WITH_LEFT_RIGHT_NEIGHBOURS
   USE ElectronParticles
   USE ClusterAndItsBoundaries, ONLY : c_X_area_min, c_X_area_max, c_Y_area_min, c_Y_area_max
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER total_part_number_to_receive
   INTEGER n
@@ -97,7 +97,7 @@ SUBROUTINE EXCHANGE_ELECTRONS_WITH_LEFT_RIGHT_NEIGHBOURS
         END DO
      ELSE
 ! send the number of particles
-        CALL MPI_SEND(N_e_to_send_right, 1, MPI_INTEGER, MOD(Rank_cluster,N_processes_cluster_right), 0, COMM_CLUSTER, request, ierr) 
+        CALL MPI_SEND(N_e_to_send_right, 1, MPI_INTEGER, MOD(Rank_cluster,N_processes_cluster_right), 0, COMM_CLUSTER, ierr) 
         IF (N_e_to_send_right.GT.0) THEN
 ! prepare array to send
            ALLOCATE(rbufer(1:N_e_to_send_right*6), STAT=ALLOC_ERR)
@@ -112,7 +112,7 @@ SUBROUTINE EXCHANGE_ELECTRONS_WITH_LEFT_RIGHT_NEIGHBOURS
               pos = pos+6
            END DO
 ! send particles
-           CALL MPI_SEND(rbufer, N_e_to_send_right*6, MPI_DOUBLE_PRECISION, MOD(Rank_cluster,N_processes_cluster_right), Rank_cluster, COMM_CLUSTER, request, ierr)     
+           CALL MPI_SEND(rbufer, N_e_to_send_right*6, MPI_DOUBLE_PRECISION, MOD(Rank_cluster,N_processes_cluster_right), Rank_cluster, COMM_CLUSTER, ierr)     
 ! clear the counter
            N_e_to_send_right = 0
            DEALLOCATE(rbufer, STAT=ALLOC_ERR)
@@ -188,7 +188,7 @@ SUBROUTINE EXCHANGE_ELECTRONS_WITH_LEFT_RIGHT_NEIGHBOURS
         END DO
      ELSE
 ! send the number of particles
-        CALL MPI_SEND(N_e_to_send_left, 1, MPI_INTEGER, MOD(Rank_cluster,N_processes_cluster_left), 0, COMM_CLUSTER, request, ierr) 
+        CALL MPI_SEND(N_e_to_send_left, 1, MPI_INTEGER, MOD(Rank_cluster,N_processes_cluster_left), 0, COMM_CLUSTER, ierr) 
         IF (N_e_to_send_left.GT.0) THEN
 ! prepare array to send
            ALLOCATE(rbufer(1:N_e_to_send_left*6), STAT=ALLOC_ERR)
@@ -203,7 +203,7 @@ SUBROUTINE EXCHANGE_ELECTRONS_WITH_LEFT_RIGHT_NEIGHBOURS
               pos = pos+6
            END DO
 ! send particles
-           CALL MPI_SEND(rbufer, N_e_to_send_left*6, MPI_DOUBLE_PRECISION, MOD(Rank_cluster,N_processes_cluster_left), Rank_cluster, COMM_CLUSTER, request, ierr)     
+           CALL MPI_SEND(rbufer, N_e_to_send_left*6, MPI_DOUBLE_PRECISION, MOD(Rank_cluster,N_processes_cluster_left), Rank_cluster, COMM_CLUSTER, ierr)     
 ! clear the counter
            N_e_to_send_left = 0
            DEALLOCATE(rbufer, STAT=ALLOC_ERR)
@@ -219,7 +219,7 @@ SUBROUTINE EXCHANGE_ELECTRONS_WITH_LEFT_RIGHT_NEIGHBOURS
 
 ! ##  1 ## send right the number of particles ----------------------------------
      IF (Rank_horizontal_right.GE.0) THEN
-        CALL MPI_SEND(N_e_to_send_right, 1, MPI_INTEGER, Rank_horizontal_right, 0, COMM_HORIZONTAL, request, ierr) 
+        CALL MPI_SEND(N_e_to_send_right, 1, MPI_INTEGER, Rank_horizontal_right, 0, COMM_HORIZONTAL, ierr) 
 
 ! ##  2 ## send right the particles
         IF (N_e_to_send_right.GT.0) THEN
@@ -235,7 +235,7 @@ SUBROUTINE EXCHANGE_ELECTRONS_WITH_LEFT_RIGHT_NEIGHBOURS
               pos = pos+6
            END DO
 ! send particles to right neighbor
-           CALL MPI_SEND(rbufer, N_e_to_send_right*6, MPI_DOUBLE_PRECISION, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, request, ierr)     
+           CALL MPI_SEND(rbufer, N_e_to_send_right*6, MPI_DOUBLE_PRECISION, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, ierr)     
 ! clear the counter
            N_e_to_send_right = 0
            DEALLOCATE(rbufer, STAT=ALLOC_ERR)
@@ -246,7 +246,7 @@ SUBROUTINE EXCHANGE_ELECTRONS_WITH_LEFT_RIGHT_NEIGHBOURS
 
 ! ##  3 ## send left the number of particles
      IF (Rank_horizontal_left.GE.0) THEN
-        CALL MPI_SEND(N_e_to_send_left, 1, MPI_INTEGER, Rank_horizontal_left, 0, COMM_HORIZONTAL, request, ierr) 
+        CALL MPI_SEND(N_e_to_send_left, 1, MPI_INTEGER, Rank_horizontal_left, 0, COMM_HORIZONTAL, ierr) 
 
 ! ##  4 ## send left the particles
         IF (N_e_to_send_left.GT.0) THEN
@@ -262,7 +262,7 @@ SUBROUTINE EXCHANGE_ELECTRONS_WITH_LEFT_RIGHT_NEIGHBOURS
               pos = pos+6
            END DO
 ! send particles to left neighbor
-           CALL MPI_SEND(rbufer, N_e_to_send_left*6, MPI_DOUBLE_PRECISION, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, request, ierr)     
+           CALL MPI_SEND(rbufer, N_e_to_send_left*6, MPI_DOUBLE_PRECISION, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, ierr)     
 ! clear the counter
            N_e_to_send_left = 0
            DEALLOCATE(rbufer, STAT=ALLOC_ERR)
@@ -441,7 +441,7 @@ SUBROUTINE EXCHANGE_ELECTRONS_WITH_LEFT_RIGHT_NEIGHBOURS
 
 ! ##  5 ## send right the number of particles ----------------------------------
      IF (Rank_horizontal_right.GE.0) THEN
-        CALL MPI_SEND(N_e_to_send_right, 1, MPI_INTEGER, Rank_horizontal_right, 0, COMM_HORIZONTAL, request, ierr) 
+        CALL MPI_SEND(N_e_to_send_right, 1, MPI_INTEGER, Rank_horizontal_right, 0, COMM_HORIZONTAL, ierr) 
 
 ! ##  6 ## send right the particles
         IF (N_e_to_send_right.GT.0) THEN
@@ -463,7 +463,7 @@ SUBROUTINE EXCHANGE_ELECTRONS_WITH_LEFT_RIGHT_NEIGHBOURS
               END DO
            END IF
 ! send particles to right neighbor
-           CALL MPI_SEND(rbufer, N_e_to_send_right*6, MPI_DOUBLE_PRECISION, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, request, ierr)     
+           CALL MPI_SEND(rbufer, N_e_to_send_right*6, MPI_DOUBLE_PRECISION, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, ierr)     
 ! clear the counter
            N_e_to_send_right = 0
            DEALLOCATE(rbufer, STAT=ALLOC_ERR)
@@ -474,7 +474,7 @@ SUBROUTINE EXCHANGE_ELECTRONS_WITH_LEFT_RIGHT_NEIGHBOURS
 
 ! ##  7 ## send left the number of particles
      IF (Rank_horizontal_left.GE.0) THEN
-        CALL MPI_SEND(N_e_to_send_left, 1, MPI_INTEGER, Rank_horizontal_left, 0, COMM_HORIZONTAL, request, ierr) 
+        CALL MPI_SEND(N_e_to_send_left, 1, MPI_INTEGER, Rank_horizontal_left, 0, COMM_HORIZONTAL, ierr) 
 
 ! ##  8 ## send left the particles
         IF (N_e_to_send_left.GT.0) THEN
@@ -496,7 +496,7 @@ SUBROUTINE EXCHANGE_ELECTRONS_WITH_LEFT_RIGHT_NEIGHBOURS
               END DO
            END IF
 ! send particles to left neighbor
-           CALL MPI_SEND(rbufer, N_e_to_send_left*6, MPI_DOUBLE_PRECISION, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, request, ierr)     
+           CALL MPI_SEND(rbufer, N_e_to_send_left*6, MPI_DOUBLE_PRECISION, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, ierr)     
 ! clear the counter
            N_e_to_send_left = 0
            DEALLOCATE(rbufer, STAT=ALLOC_ERR)
@@ -521,9 +521,9 @@ SUBROUTINE EXCHANGE_ELECTRONS_WITH_ABOVE_BELOW_NEIGHBOURS
   USE ElectronParticles
   USE ClusterAndItsBoundaries, ONLY : c_X_area_min, c_X_area_max, c_Y_area_min, c_Y_area_max
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER total_part_number_to_receive
   INTEGER n
@@ -611,7 +611,7 @@ SUBROUTINE EXCHANGE_ELECTRONS_WITH_ABOVE_BELOW_NEIGHBOURS
         END DO
      ELSE
 ! send the number of particles
-        CALL MPI_SEND(N_e_to_send_above, 1, MPI_INTEGER, MOD(Rank_cluster,N_processes_cluster_above), 0, COMM_CLUSTER, request, ierr) 
+        CALL MPI_SEND(N_e_to_send_above, 1, MPI_INTEGER, MOD(Rank_cluster,N_processes_cluster_above), 0, COMM_CLUSTER, ierr) 
         IF (N_e_to_send_above.GT.0) THEN
 ! prepare array to send
            ALLOCATE(rbufer(1:N_e_to_send_above*6), STAT=ALLOC_ERR)
@@ -626,7 +626,7 @@ SUBROUTINE EXCHANGE_ELECTRONS_WITH_ABOVE_BELOW_NEIGHBOURS
               pos = pos+6
            END DO
 ! send particles
-           CALL MPI_SEND(rbufer, N_e_to_send_above*6, MPI_DOUBLE_PRECISION, MOD(Rank_cluster,N_processes_cluster_above), Rank_cluster, COMM_CLUSTER, request, ierr)     
+           CALL MPI_SEND(rbufer, N_e_to_send_above*6, MPI_DOUBLE_PRECISION, MOD(Rank_cluster,N_processes_cluster_above), Rank_cluster, COMM_CLUSTER, ierr)     
 ! clear the counter
            N_e_to_send_above = 0
            DEALLOCATE(rbufer, STAT=ALLOC_ERR)
@@ -702,7 +702,7 @@ SUBROUTINE EXCHANGE_ELECTRONS_WITH_ABOVE_BELOW_NEIGHBOURS
         END DO
      ELSE
 ! send the number of particles
-        CALL MPI_SEND(N_e_to_send_below, 1, MPI_INTEGER, MOD(Rank_cluster,N_processes_cluster_below), 0, COMM_CLUSTER, request, ierr) 
+        CALL MPI_SEND(N_e_to_send_below, 1, MPI_INTEGER, MOD(Rank_cluster,N_processes_cluster_below), 0, COMM_CLUSTER, ierr) 
         IF (N_e_to_send_below.GT.0) THEN
 ! prepare array to send
            ALLOCATE(rbufer(1:N_e_to_send_below*6), STAT=ALLOC_ERR)
@@ -717,7 +717,7 @@ SUBROUTINE EXCHANGE_ELECTRONS_WITH_ABOVE_BELOW_NEIGHBOURS
               pos = pos+6
            END DO
 ! send particles
-           CALL MPI_SEND(rbufer, N_e_to_send_below*6, MPI_DOUBLE_PRECISION, MOD(Rank_cluster,N_processes_cluster_below), Rank_cluster, COMM_CLUSTER, request, ierr)     
+           CALL MPI_SEND(rbufer, N_e_to_send_below*6, MPI_DOUBLE_PRECISION, MOD(Rank_cluster,N_processes_cluster_below), Rank_cluster, COMM_CLUSTER, ierr)     
 ! clear the counter
            N_e_to_send_below = 0
            DEALLOCATE(rbufer, STAT=ALLOC_ERR)
@@ -733,7 +733,7 @@ SUBROUTINE EXCHANGE_ELECTRONS_WITH_ABOVE_BELOW_NEIGHBOURS
 
 ! ##  9 ## send up the number of particles -------------------------------------
      IF (Rank_horizontal_above.GE.0) THEN
-        CALL MPI_SEND(N_e_to_send_above, 1, MPI_INTEGER, Rank_horizontal_above, 0, COMM_HORIZONTAL, request, ierr) 
+        CALL MPI_SEND(N_e_to_send_above, 1, MPI_INTEGER, Rank_horizontal_above, 0, COMM_HORIZONTAL, ierr) 
 
 ! ## 10 ## send up the particles
         IF (N_e_to_send_above.GT.0) THEN
@@ -749,7 +749,7 @@ SUBROUTINE EXCHANGE_ELECTRONS_WITH_ABOVE_BELOW_NEIGHBOURS
               pos = pos+6
            END DO
 ! send particles to neighbor above
-           CALL MPI_SEND(rbufer, N_e_to_send_above*6, MPI_DOUBLE_PRECISION, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, request, ierr)     
+           CALL MPI_SEND(rbufer, N_e_to_send_above*6, MPI_DOUBLE_PRECISION, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, ierr)     
 ! clear the counter
            N_e_to_send_above = 0
            DEALLOCATE(rbufer, STAT=ALLOC_ERR)
@@ -760,7 +760,7 @@ SUBROUTINE EXCHANGE_ELECTRONS_WITH_ABOVE_BELOW_NEIGHBOURS
 
 ! ## 11 ## send down the number of particles
      IF (Rank_horizontal_below.GE.0) THEN
-        CALL MPI_SEND(N_e_to_send_below, 1, MPI_INTEGER, Rank_horizontal_below, 0, COMM_HORIZONTAL, request, ierr) 
+        CALL MPI_SEND(N_e_to_send_below, 1, MPI_INTEGER, Rank_horizontal_below, 0, COMM_HORIZONTAL, ierr) 
 
 ! ## 12 ## send down the particles
         IF (N_e_to_send_below.GT.0) THEN
@@ -776,7 +776,7 @@ SUBROUTINE EXCHANGE_ELECTRONS_WITH_ABOVE_BELOW_NEIGHBOURS
               pos = pos+6
            END DO
 ! send particles to neighbor below
-           CALL MPI_SEND(rbufer, N_e_to_send_below*6, MPI_DOUBLE_PRECISION, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, request, ierr)     
+           CALL MPI_SEND(rbufer, N_e_to_send_below*6, MPI_DOUBLE_PRECISION, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, ierr)     
 ! clear the counter
            N_e_to_send_below = 0
            DEALLOCATE(rbufer, STAT=ALLOC_ERR)
@@ -960,7 +960,7 @@ SUBROUTINE EXCHANGE_ELECTRONS_WITH_ABOVE_BELOW_NEIGHBOURS
 
 ! ## 13 ## send up the number of particles -------------------------------------
      IF (Rank_horizontal_above.GE.0) THEN
-        CALL MPI_SEND(N_e_to_send_above, 1, MPI_INTEGER, Rank_horizontal_above, 0, COMM_HORIZONTAL, request, ierr) 
+        CALL MPI_SEND(N_e_to_send_above, 1, MPI_INTEGER, Rank_horizontal_above, 0, COMM_HORIZONTAL, ierr) 
 
 ! ## 14 ## send up the particles
         IF (N_e_to_send_above.GT.0) THEN
@@ -982,7 +982,7 @@ SUBROUTINE EXCHANGE_ELECTRONS_WITH_ABOVE_BELOW_NEIGHBOURS
               END DO
            END IF
 ! send particles to neighbor above
-           CALL MPI_SEND(rbufer, N_e_to_send_above*6, MPI_DOUBLE_PRECISION, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, request, ierr)     
+           CALL MPI_SEND(rbufer, N_e_to_send_above*6, MPI_DOUBLE_PRECISION, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, ierr)     
 ! clear the counter
            N_e_to_send_above = 0
            DEALLOCATE(rbufer, STAT=ALLOC_ERR)
@@ -993,7 +993,7 @@ SUBROUTINE EXCHANGE_ELECTRONS_WITH_ABOVE_BELOW_NEIGHBOURS
 
 ! ## 15 ## send down the number of particles
      IF (Rank_horizontal_below.GE.0) THEN
-        CALL MPI_SEND(N_e_to_send_below, 1, MPI_INTEGER, Rank_horizontal_below, 0, COMM_HORIZONTAL, request, ierr) 
+        CALL MPI_SEND(N_e_to_send_below, 1, MPI_INTEGER, Rank_horizontal_below, 0, COMM_HORIZONTAL, ierr) 
 
 ! ## 16 ## send down the particles
         IF (N_e_to_send_below.GT.0) THEN
@@ -1015,7 +1015,7 @@ SUBROUTINE EXCHANGE_ELECTRONS_WITH_ABOVE_BELOW_NEIGHBOURS
               END DO
            END IF
 ! send particles to neighbor below
-           CALL MPI_SEND(rbufer, N_e_to_send_below*6, MPI_DOUBLE_PRECISION, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, request, ierr)     
+           CALL MPI_SEND(rbufer, N_e_to_send_below*6, MPI_DOUBLE_PRECISION, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, ierr)     
 ! clear the counter
            N_e_to_send_below = 0
            DEALLOCATE(rbufer, STAT=ALLOC_ERR)

--- a/src/pic2d_ElectronMoments.f90
+++ b/src/pic2d_ElectronMoments.f90
@@ -8,9 +8,10 @@ SUBROUTINE COLLECT_ELECTRON_MOMENTS
   USE ClusterAndItsBoundaries
   USE Snapshots
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
   INTEGER stattus(MPI_STATUS_SIZE)
@@ -432,9 +433,10 @@ SUBROUTINE SYNCHRONIZE_MOMENTS_IN_OVERLAP_NODES
   USE ClusterAndItsBoundaries
   USE Snapshots
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER ierr
   INTEGER stattus(MPI_STATUS_SIZE)
@@ -507,7 +509,7 @@ SUBROUTINE SYNCHRONIZE_MOMENTS_IN_OVERLAP_NODES
         pos2=pos2+n1
         rbufer(pos1:pos2) = cs_QZ(c_indx_x_max, c_indx_y_min:c_indx_y_max)
 
-        CALL MPI_SEND(rbufer, 13*n1, MPI_REAL, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+        CALL MPI_SEND(rbufer, 13*n1, MPI_REAL, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, ierr) 
      END IF
 
      IF (Rank_horizontal_left.GE.0) THEN
@@ -556,7 +558,7 @@ SUBROUTINE SYNCHRONIZE_MOMENTS_IN_OVERLAP_NODES
         pos2=pos2+n1
         rbufer(pos1:pos2) = cs_QZ(c_indx_x_min, c_indx_y_min:c_indx_y_max)
 
-        CALL MPI_SEND(rbufer, 13*n1, MPI_REAL, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+        CALL MPI_SEND(rbufer, 13*n1, MPI_REAL, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, ierr) 
      END IF
 
      IF (Rank_horizontal_left.GE.0) THEN
@@ -734,7 +736,7 @@ SUBROUTINE SYNCHRONIZE_MOMENTS_IN_OVERLAP_NODES
         pos2=pos2+n3
         rbufer(pos1:pos2) = cs_QZ(c_indx_x_min:c_indx_x_max, c_indx_y_max)
 
-        CALL MPI_SEND(rbufer, 13*n3, MPI_REAL, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+        CALL MPI_SEND(rbufer, 13*n3, MPI_REAL, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, ierr) 
      END IF
 
      IF (Rank_horizontal_below.GE.0) THEN
@@ -783,7 +785,7 @@ SUBROUTINE SYNCHRONIZE_MOMENTS_IN_OVERLAP_NODES
         pos2=pos2+n3
         rbufer(pos1:pos2) = cs_QZ(c_indx_x_min:c_indx_x_max, c_indx_y_min)
 
-        CALL MPI_SEND(rbufer, 13*n3, MPI_REAL, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+        CALL MPI_SEND(rbufer, 13*n3, MPI_REAL, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, ierr) 
      END IF
 
      IF (Rank_horizontal_below.GE.0) THEN
@@ -1090,7 +1092,7 @@ SUBROUTINE SYNCHRONIZE_MOMENTS_IN_OVERLAP_NODES
         pos2=pos2+n1
         rbufer(pos1:pos2) = cs_QZ(c_indx_x_max, c_indx_y_min:c_indx_y_max)
 
-        CALL MPI_SEND(rbufer, 13*n1, MPI_REAL, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+        CALL MPI_SEND(rbufer, 13*n1, MPI_REAL, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, ierr) 
      END IF
 
      IF (Rank_horizontal_left.GE.0) THEN
@@ -1139,7 +1141,7 @@ SUBROUTINE SYNCHRONIZE_MOMENTS_IN_OVERLAP_NODES
         pos2=pos2+n1
         rbufer(pos1:pos2) = cs_QZ(c_indx_x_min, c_indx_y_min:c_indx_y_max)
 
-        CALL MPI_SEND(rbufer, 13*n1, MPI_REAL, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+        CALL MPI_SEND(rbufer, 13*n1, MPI_REAL, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, ierr) 
      END IF
 
      IF (ALLOCATED(rbufer)) DEALLOCATE(rbufer, STAT=ALLOC_ERR)
@@ -1315,7 +1317,7 @@ SUBROUTINE SYNCHRONIZE_MOMENTS_IN_OVERLAP_NODES
         pos2=pos2+n3
         rbufer(pos1:pos2) = cs_QZ(c_indx_x_min:c_indx_x_max, c_indx_y_max)
 
-        CALL MPI_SEND(rbufer, 13*n3, MPI_REAL, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+        CALL MPI_SEND(rbufer, 13*n3, MPI_REAL, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, ierr) 
      END IF
 
      IF (Rank_horizontal_below.GE.0) THEN
@@ -1364,7 +1366,7 @@ SUBROUTINE SYNCHRONIZE_MOMENTS_IN_OVERLAP_NODES
         pos2=pos2+n3
         rbufer(pos1:pos2) = cs_QZ(c_indx_x_min:c_indx_x_max, c_indx_y_min)
 
-        CALL MPI_SEND(rbufer, 13*n3, MPI_REAL, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+        CALL MPI_SEND(rbufer, 13*n3, MPI_REAL, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, ierr) 
      END IF
 
   END IF   !###   IF (WHITE_CLUSTER) THEN
@@ -1419,7 +1421,7 @@ SUBROUTINE SYNCHRONIZE_MOMENTS_IN_OVERLAP_NODES
      pos2=pos2+n1
      rbufer(pos1:pos2) = cs_QZ(c_indx_x_min+1, c_indx_y_min:c_indx_y_max)
 
-     CALL MPI_SEND(rbufer, 13*n1, MPI_REAL, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+     CALL MPI_SEND(rbufer, 13*n1, MPI_REAL, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, ierr) 
 
 ! ## 2 ## receive from left moments in the vertical line AT the left edge
      CALL MPI_RECV(rbufer, 13*n1, MPI_REAL, Rank_horizontal_left, Rank_horizontal_left, COMM_HORIZONTAL, stattus, ierr)
@@ -1591,7 +1593,7 @@ SUBROUTINE SYNCHRONIZE_MOMENTS_IN_OVERLAP_NODES
      pos2=pos2+n1
      rbufer(pos1:pos2) = cs_QZ(c_indx_x_max-1, c_indx_y_min:c_indx_y_max)
 
-     CALL MPI_SEND(rbufer, 13*n1, MPI_REAL, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+     CALL MPI_SEND(rbufer, 13*n1, MPI_REAL, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, ierr) 
 
   END IF   !###   IF (periodic_boundary_X_left) THEN
 
@@ -1645,7 +1647,7 @@ SUBROUTINE SYNCHRONIZE_MOMENTS_IN_OVERLAP_NODES
      pos2=pos2+n3
      rbufer(pos1:pos2) = cs_QZ(c_indx_x_min:c_indx_x_max, c_indx_y_min+1)
 
-     CALL MPI_SEND(rbufer, 13*n3, MPI_REAL, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+     CALL MPI_SEND(rbufer, 13*n3, MPI_REAL, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, ierr) 
  
 ! ## 2 ## receive from below moments in the bottom line
      CALL MPI_RECV(rbufer, 13*n3, MPI_REAL, Rank_horizontal_below, Rank_horizontal_below, COMM_HORIZONTAL, stattus, ierr)
@@ -1817,7 +1819,7 @@ SUBROUTINE SYNCHRONIZE_MOMENTS_IN_OVERLAP_NODES
      pos2=pos2+n3
      rbufer(pos1:pos2) = cs_QZ(c_indx_x_min:c_indx_x_max, c_indx_y_max-1)
 
-     CALL MPI_SEND(rbufer, 13*n3, MPI_REAL, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+     CALL MPI_SEND(rbufer, 13*n3, MPI_REAL, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, ierr) 
  
   END IF   !###   IF (periodic_boundary_Y_below) THEN
 
@@ -1832,6 +1834,8 @@ SUBROUTINE ADJUST_DENSITY_AT_WALL_BOUNDARIES
   USE ParallelOperationValues
   USE ClusterAndItsBoundaries
   USE Snapshots
+
+  use mpi
 
   IMPLICIT NONE
 

--- a/src/pic2d_ElectronWallCollisions.f90
+++ b/src/pic2d_ElectronWallCollisions.f90
@@ -6,9 +6,10 @@ SUBROUTINE PROCESS_ELECTRON_COLL_WITH_BOUNDARY_LEFT(x, y, vx, vy, vz, tag)
   USE ClusterAndItsBoundaries
   USE CurrentProblemValues, ONLY : whole_object, VACUUM_GAP, METAL_WALL, DIELECTRIC
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
 
@@ -79,9 +80,10 @@ SUBROUTINE PROCESS_ELECTRON_COLL_WITH_BOUNDARY_RIGHT(x, y, vx, vy, vz, tag)
   USE ClusterAndItsBoundaries
   USE CurrentProblemValues, ONLY : whole_object, VACUUM_GAP, METAL_WALL, DIELECTRIC
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
 
@@ -152,9 +154,10 @@ SUBROUTINE PROCESS_ELECTRON_COLL_WITH_BOUNDARY_BELOW(x, y, vx, vy, vz, tag)
   USE ClusterAndItsBoundaries
   USE CurrentProblemValues, ONLY : whole_object, VACUUM_GAP, METAL_WALL, DIELECTRIC
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
 
@@ -225,9 +228,10 @@ SUBROUTINE PROCESS_ELECTRON_COLL_WITH_BOUNDARY_ABOVE(x, y, vx, vy, vz, tag)
   USE ClusterAndItsBoundaries
   USE CurrentProblemValues, ONLY : whole_object, VACUUM_GAP, METAL_WALL, DIELECTRIC
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
 
@@ -299,9 +303,10 @@ SUBROUTINE COLLECT_ELECTRON_BOUNDARY_HITS
   USE ClusterAndItsBoundaries
   USE IonParticles, ONLY : N_spec
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER ierr
 !  INTEGER stattus(MPI_STATUS_SIZE)
@@ -349,6 +354,8 @@ SUBROUTINE INITIATE_WALL_DIAGNOSTICS
   USE Checkpoints, ONLY : use_checkpoint
 !  USE Diagnostics, ONLY : N_of_saved_records
   USE SetupValues, ONLY : ht_use_e_emission_from_cathode, ht_use_e_emission_from_cathode_zerogradf, ht_emission_constant
+
+  use mpi
 
   IMPLICIT NONE
 
@@ -423,6 +430,8 @@ SUBROUTINE SAVE_BOUNDARY_PARTICLE_HITS_EMISSIONS
   USE IonParticles, ONLY : N_spec, Qs
   USE ExternalCircuit
 
+  use mpi
+
   IMPLICIT NONE
 
   INTEGER nn, noi, s
@@ -477,9 +486,10 @@ SUBROUTINE TRY_ELECTRON_COLL_WITH_INNER_OBJECT(x, y, vx, vy, vz, tag) !, myobjec
   USE ClusterAndItsBoundaries
   USE CurrentProblemValues !, ONLY : inner_object, METAL_WALL, DIELECTRIC
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
 
@@ -569,6 +579,8 @@ SUBROUTINE DO_ELECTRON_COLL_WITH_INNER_OBJECT(x, y, vx, vy, vz, tag, myobject, c
   USE ClusterAndItsBoundaries
   USE CurrentProblemValues !, ONLY : inner_object, METAL_WALL, DIELECTRIC
 
+  use mpi
+
   IMPLICIT NONE
 
 !  INTEGER nio  ! number of the inner object
@@ -654,6 +666,8 @@ END SUBROUTINE DO_ELECTRON_COLL_WITH_INNER_OBJECT
 SUBROUTINE FIND_CLOSEST_INTERSECTION_WITH_OBJECT(xorg, yorg, x, y, n, mcross, xcross, ycross, distorg)
 
   USE CurrentProblemValues !, ONLY : inner_object, METAL_WALL, DIELECTRIC
+
+  use mpi
 
   IMPLICIT NONE
 
@@ -753,6 +767,8 @@ SUBROUTINE CHECK_INTERSECTION_WITH_VERTICAL_SEGMENT( xorg, yorg, x, y, xseg, ymi
 
   use, intrinsic :: ieee_arithmetic
 
+  use mpi
+
   IMPLICIT NONE
 
   REAL(8), INTENT(IN) :: xorg, yorg, x, y          ! coordinates of the ends of particle trajectory segment
@@ -796,6 +812,8 @@ END SUBROUTINE CHECK_INTERSECTION_WITH_VERTICAL_SEGMENT
 SUBROUTINE CHECK_INTERSECTION_WITH_HORIZONTAL_SEGMENT( xorg, yorg, x, y, yseg, xminseg, xmaxseg, mystatus, xcross )
 
   use, intrinsic :: ieee_arithmetic
+
+  use mpi
 
   IMPLICIT NONE
 
@@ -842,9 +860,10 @@ SUBROUTINE PrepareMaxwellDistribIntegral
   USE ParallelOperationValues
   USE MaxwellVelocity
 !  USE CurrentProblemValues, ONLY : N_box_vel
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
 
@@ -942,6 +961,8 @@ SUBROUTINE GetInjMaxwellVelocity(U)
  
   USE rng_wrapper
 
+  use mpi
+
   IMPLICIT NONE
 
   REAL(8) U
@@ -970,6 +991,8 @@ SUBROUTINE GetMaxwellVelocity(U)
 
   USE rng_wrapper
 
+  use mpi
+
   IMPLICIT NONE
 
   REAL(8) U
@@ -994,6 +1017,8 @@ END SUBROUTINE GetMaxwellVelocity
 !
 REAL(8) FUNCTION vector_product_z(ax, ay, bx, by)
 
+  use mpi
+
   IMPLICIT NONE
   REAL(8) ax, ay, bx, by
 
@@ -1007,6 +1032,8 @@ SUBROUTINE ADD_ELECTRON_TO_BO_COLLS_LIST(coll_coord, vx, vy, vz, tag, nwo, nseg)
 
   USE CurrentProblemValues, ONLY : e_colls_with_bo
   USE Snapshots
+
+  use mpi
 
   IMPLICIT NONE
 

--- a/src/pic2d_ExternalCircuits.f90
+++ b/src/pic2d_ExternalCircuits.f90
@@ -7,9 +7,10 @@ SUBROUTINE CALCULATE_OBJECT_POTENTIALS_2D
   USE CurrentProblemValues
   USE BlockAndItsBoundaries
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER ierr
 
@@ -80,9 +81,10 @@ SUBROUTINE CALCULATE_OBJECT_POTENTIAL_CHARGE_COEFFS
   USE CurrentProblemValues
   USE BlockAndItsBoundaries
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
 
@@ -1538,9 +1540,10 @@ SUBROUTINE ADD_MORE_CONTROL_POINTS(nn, N_to_add)
 
   USE ExternalCircuit
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
 
@@ -1664,9 +1667,10 @@ SUBROUTINE SOLVE_EXTERNAL_CONTOUR
   USE IonParticles, ONLY : N_spec, Qs
   USE Diagnostics, ONLY : Save_probes_e_data_T_cntr, N_of_probes_block, Probe_params_block_list, probe_F_block
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
 

--- a/src/pic2d_ExternalFields.f90
+++ b/src/pic2d_ExternalFields.f90
@@ -7,9 +7,10 @@ SUBROUTINE PREPARE_EXTERNAL_FIELDS
   USE CurrentProblemValues, ONLY : E_scale_Vm, B_scale_T, delta_x_m, global_maximal_j, pi, mu_0_Hm
   USE IonParticles, ONLY : ions_sense_magnetic_field, ions_sense_EZ
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   LOGICAL exists
 
@@ -197,6 +198,8 @@ REAL(8) FUNCTION Bx(x, y)
 
   USE ExternalFields
 
+  use mpi
+
   IMPLICIT NONE
 
   REAL(8) x, y
@@ -216,6 +219,8 @@ REAL(8) FUNCTION By(x, y)
 
   USE ExternalFields
 
+  use mpi
+
   IMPLICIT NONE
 
   REAL(8) x, y
@@ -234,6 +239,8 @@ END FUNCTION By
 REAL(8) FUNCTION Bz(x, y)
 
   USE ExternalFields
+
+  use mpi
 
   IMPLICIT NONE
 
@@ -258,6 +265,8 @@ END FUNCTION Bz
 REAL(8) FUNCTION Ez(x, y)
 
   USE ExternalFields
+
+  use mpi
 
   IMPLICIT NONE
 

--- a/src/pic2d_HTSetup.f90
+++ b/src/pic2d_HTSetup.f90
@@ -8,6 +8,8 @@ SUBROUTINE PREPARE_HT_SETUP_VALUES
   USE IonParticles
   USE ClusterAndItsBoundaries
 
+  use mpi
+
   IMPLICIT NONE
 
   LOGICAl exists
@@ -209,6 +211,8 @@ SUBROUTINE PrepareYIonizRateDistribIntegral
   USE CurrentProblemValues, ONLY : whole_object
   USE IonParticles, ONLY : N_spec
 
+  use mpi
+
   IMPLICIT NONE
 
   INTEGER N_pnts
@@ -344,9 +348,10 @@ SUBROUTINE PERFORM_IONIZATION_HT_SETUP
 
   USE rng_wrapper
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER ierr
 
@@ -414,6 +419,8 @@ SUBROUTINE GetYCoordIoniz(y)
 
   USE rng_wrapper
 
+  use mpi
+
   IMPLICIT NONE
 
   REAL(8) y
@@ -443,6 +450,8 @@ REAL(8) FUNCTION RateDistrFun(y)
 
   USE SetupValues, ONLY : j_ion_source_1, j_ion_source_2
   
+
+  use mpi
 
   IMPLICIT NONE
 
@@ -474,9 +483,10 @@ SUBROUTINE PERFORM_ELECTRON_EMISSION_HT_SETUP
 
   USE rng_wrapper
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER ierr
 
@@ -618,9 +628,10 @@ SUBROUTINE PERFORM_ELECTRON_EMISSION_HT_SETUP_ZERO_GRAD_F
 
   USE rng_wrapper
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER ierr
   INTEGER stattus(MPI_STATUS_SIZE)
@@ -845,13 +856,13 @@ print '("      Process ",i4," will emit ",i7," electron macroparticles")', Rank_
         IF (Rank_horizontal_right.GE.0) THEN
 ! ## 1 ## send right densities in the right edge
            rbufer(1:2) = temp_c_rho_band(c_indx_x_max-1:c_indx_x_max)
-           CALL MPI_SEND(rbufer, 2, MPI_DOUBLE_PRECISION, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, 2, MPI_DOUBLE_PRECISION, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
         IF (Rank_horizontal_left.GE.0) THEN
 ! ## 2 ## send left densities in the left edge
            rbufer(1:2) = temp_c_rho_band(c_indx_x_min:c_indx_x_min+1)
-           CALL MPI_SEND(rbufer, 2, MPI_DOUBLE_PRECISION, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, 2, MPI_DOUBLE_PRECISION, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
         IF (Rank_horizontal_left.GE.0) THEN
@@ -884,13 +895,13 @@ print '("      Process ",i4," will emit ",i7," electron macroparticles")', Rank_
         IF (Rank_horizontal_right.GE.0) THEN
 ! ## 3 ## send right densities in the right edge
            rbufer(1:2) = temp_c_rho_band(c_indx_x_max-1:c_indx_x_max)
-           CALL MPI_SEND(rbufer, 2, MPI_DOUBLE_PRECISION, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, 2, MPI_DOUBLE_PRECISION, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
         IF (Rank_horizontal_left.GE.0) THEN
 ! ## 4 ## send left densities in the left edge
            rbufer(1:2) = temp_c_rho_band(c_indx_x_min:c_indx_x_min+1)
-           CALL MPI_SEND(rbufer, 2, MPI_DOUBLE_PRECISION, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, 2, MPI_DOUBLE_PRECISION, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
      END IF
@@ -919,6 +930,8 @@ SUBROUTINE INITIATE_WALL_DIAGNOSTICS_HT_SETUP
   USE Checkpoints
   USE Diagnostics
   USE SetupValues, ONLY : ht_use_e_emission_from_cathode, ht_use_e_emission_from_cathode_zerogradf, ht_emission_constant
+
+  use mpi
 
   IMPLICIT NONE
 
@@ -978,6 +991,8 @@ SUBROUTINE SAVE_BOUNDARY_PARTICLE_HITS_EMISSIONS_HT_SETUP
   USE CurrentProblemValues
   USE SetupValues, ONLY : total_cathode_N_e_to_inject, total_cathode_N_e_injected, &
                         & ht_use_e_emission_from_cathode, ht_use_e_emission_from_cathode_zerogradf, ht_emission_constant
+
+  use mpi
 
   IMPLICIT NONE
 

--- a/src/pic2d_IonDynamics.f90
+++ b/src/pic2d_IonDynamics.f90
@@ -7,9 +7,10 @@ SUBROUTINE ADVANCE_IONS
   USE IonParticles
   USE ClusterAndItsBoundaries
   
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
 
@@ -534,9 +535,10 @@ SUBROUTINE REMOVE_ION(s, k)
   USE ParallelOperationValues
   USE IonParticles
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
 
@@ -584,6 +586,8 @@ SUBROUTINE ADD_ION_TO_SEND_LEFT(s, x, y, vx, vy, vz, tag)
 
 !use CurrentProblemValues, only : T_cntr
 !USE ParallelOperationValues, only : Rank_of_process
+
+  use mpi
 
   IMPLICIT NONE
 
@@ -661,6 +665,8 @@ SUBROUTINE ADD_ION_TO_SEND_RIGHT(s, x, y, vx, vy, vz, tag)
 !use CurrentProblemValues, only : T_cntr
 !USE ParallelOperationValues, only : Rank_of_process
 
+  use mpi
+
   IMPLICIT NONE
 
   INTEGER s
@@ -736,6 +742,8 @@ SUBROUTINE ADD_ION_TO_SEND_ABOVE(s, x, y, vx, vy, vz, tag)
 
 !use CurrentProblemValues, only : T_cntr
 !USE ParallelOperationValues, only : Rank_of_process
+
+  use mpi
 
   IMPLICIT NONE
 
@@ -813,6 +821,8 @@ SUBROUTINE ADD_ION_TO_SEND_BELOW(s, x, y, vx, vy, vz, tag)
 !use CurrentProblemValues, only : T_cntr
 !USE ParallelOperationValues, only : Rank_of_process
 
+  use mpi
+
   IMPLICIT NONE
 
   INTEGER s
@@ -885,6 +895,8 @@ SUBROUTINE ADD_ION_TO_ADD_LIST(s, x, y, vx, vy, vz, tag)
 
   USE IonParticles, ONLY : N_ions_to_add, max_N_ions_to_add, ion_to_add
 
+  use mpi
+
   IMPLICIT NONE
 
   INTEGER s
@@ -952,9 +964,10 @@ SUBROUTINE REMOVE_ION_FROM_ADD_LIST(s, k)
   USE ParallelOperationValues
   USE IonParticles
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
 
@@ -1002,9 +1015,10 @@ SUBROUTINE FIND_ALIENS_IN_ION_ADD_LIST
   USE ClusterAndItsBoundaries
   USE IonParticles, ONLY : N_ions_to_add, ion_to_add, N_spec
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
 
@@ -1458,6 +1472,8 @@ SUBROUTINE FIND_INNER_OBJECT_COLL_IN_ION_ADD_LIST
   USE CurrentProblemValues
   USE IonParticles, ONLY : N_ions_to_add, ion_to_add, N_spec
 
+  use mpi
+
   IMPLICIT NONE
 
   INTEGER s, k, n 
@@ -1501,6 +1517,8 @@ SUBROUTINE PROCESS_ADDED_IONS
   USE CurrentProblemValues
 
   USE IonParticles, ONLY : N_ions_to_add, N_ions, max_N_ions, ion, ion_to_add, N_spec
+
+  use mpi
 
   IMPLICIT NONE
 
@@ -1576,9 +1594,10 @@ SUBROUTINE GATHER_ION_CHARGE_DENSITY
   USE BlockAndItsBoundaries, ONLY : indx_x_min, indx_x_max, indx_y_min, indx_y_max
 !  USE Diagnostics
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
   INTEGER stattus(MPI_STATUS_SIZE)
@@ -1746,13 +1765,13 @@ SUBROUTINE GATHER_ION_CHARGE_DENSITY
         IF (Rank_horizontal_right.GE.0) THEN
 ! ## 1 ## send right densities in the right edge
            rbufer(1:n1) = c_rho_i(c_indx_x_max, c_indx_y_min:c_indx_y_max)
-           CALL MPI_SEND(rbufer, n1, MPI_DOUBLE_PRECISION, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, n1, MPI_DOUBLE_PRECISION, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
         IF (Rank_horizontal_left.GE.0) THEN
 ! ## 2 ## send left densities in the left edge
            rbufer(1:n1) = c_rho_i(c_indx_x_min, c_indx_y_min:c_indx_y_max)
-           CALL MPI_SEND(rbufer, n1, MPI_DOUBLE_PRECISION, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, n1, MPI_DOUBLE_PRECISION, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
         IF (Rank_horizontal_left.GE.0) THEN
@@ -1777,13 +1796,13 @@ SUBROUTINE GATHER_ION_CHARGE_DENSITY
         IF (Rank_horizontal_above.GE.0) THEN
 ! ## 5 ## send up densities in the top edge
            rbufer(1:n3) = c_rho_i(c_indx_x_min:c_indx_x_max, c_indx_y_max)
-           CALL MPI_SEND(rbufer, n3, MPI_DOUBLE_PRECISION, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, n3, MPI_DOUBLE_PRECISION, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
         IF (Rank_horizontal_below.GE.0) THEN
 ! ## 6 ## send down densities in the bottom edge
            rbufer(1:n3) = c_rho_i(c_indx_x_min:c_indx_x_max, c_indx_y_min)
-           CALL MPI_SEND(rbufer, n3, MPI_DOUBLE_PRECISION, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, n3, MPI_DOUBLE_PRECISION, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
         IF (Rank_horizontal_below.GE.0) THEN
@@ -1827,13 +1846,13 @@ SUBROUTINE GATHER_ION_CHARGE_DENSITY
         IF (Rank_horizontal_right.GE.0) THEN
 ! ## 3 ## send right densities in the right edge
            rbufer(1:n1) = c_rho_i(c_indx_x_max, c_indx_y_min:c_indx_y_max)
-           CALL MPI_SEND(rbufer, n1, MPI_DOUBLE_PRECISION, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, n1, MPI_DOUBLE_PRECISION, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
         IF (Rank_horizontal_left.GE.0) THEN
 ! ## 4 ## send left densities in the left edge
            rbufer(1:n1) = c_rho_i(c_indx_x_min, c_indx_y_min:c_indx_y_max)
-           CALL MPI_SEND(rbufer, n1, MPI_DOUBLE_PRECISION, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, n1, MPI_DOUBLE_PRECISION, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
         IF (ALLOCATED(rbufer)) DEALLOCATE(rbufer, STAT=ALLOC_ERR)
@@ -1858,13 +1877,13 @@ SUBROUTINE GATHER_ION_CHARGE_DENSITY
         IF (Rank_horizontal_above.GE.0) THEN
 ! ## 7 ## send up densities in the top edge
            rbufer(1:n3) = c_rho_i(c_indx_x_min:c_indx_x_max, c_indx_y_max)
-           CALL MPI_SEND(rbufer, n3, MPI_DOUBLE_PRECISION, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, n3, MPI_DOUBLE_PRECISION, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
         IF (Rank_horizontal_below.GE.0) THEN
 ! ## 8 ## send down densities in the bottom edge
            rbufer(1:n3) = c_rho_i(c_indx_x_min:c_indx_x_max, c_indx_y_min)
-           CALL MPI_SEND(rbufer, n3, MPI_DOUBLE_PRECISION, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+           CALL MPI_SEND(rbufer, n3, MPI_DOUBLE_PRECISION, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, ierr) 
         END IF
 
      END IF
@@ -1981,7 +2000,7 @@ SUBROUTINE GATHER_ION_CHARGE_DENSITY
 
               END DO
            END DO
-           CALL MPI_SEND(rbufer, bufsize, MPI_DOUBLE_PRECISION, field_calculator(k)%rank, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+           CALL MPI_SEND(rbufer, bufsize, MPI_DOUBLE_PRECISION, field_calculator(k)%rank, Rank_of_process, MPI_COMM_WORLD, ierr) 
         END DO
 
 ! cluster master is a field calaculator too, prepare its own charge density

--- a/src/pic2d_IonDynamicsWithVDFMoments.f90
+++ b/src/pic2d_IonDynamicsWithVDFMoments.f90
@@ -10,9 +10,10 @@ SUBROUTINE ADVANCE_IONS_PLUS
   USE IonParticles, ONLY : N_spec, N_ions_to_send_left, N_ions_to_send_right, N_ions_to_send_above, N_ions_to_send_below
   USE Diagnostics, ONLY : Save_probes_i_data_T_cntr
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER ierr
 
@@ -189,9 +190,10 @@ SUBROUTINE ADVANCE_IONS_AND_CALCULATE_MOMENTS_2D(s)
   USE Diagnostics
 !------------------------------------------<<<
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER, INTENT(IN) :: s
 
@@ -1041,9 +1043,10 @@ SUBROUTINE ADVANCE_IONS_AND_CALCULATE_MOMENTS_PROBES
   
   USE Diagnostics
   
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
 

--- a/src/pic2d_IonMoments.f90
+++ b/src/pic2d_IonMoments.f90
@@ -7,9 +7,10 @@ SUBROUTINE COLLECT_ION_MOMENTS(s)
   USE ClusterAndItsBoundaries
   USE Snapshots
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER, INTENT(IN) :: s
 

--- a/src/pic2d_IonWallCollisions.f90
+++ b/src/pic2d_IonWallCollisions.f90
@@ -7,9 +7,9 @@ SUBROUTINE PROCESS_ION_COLL_WITH_BOUNDARY_LEFT(s, x, y, vx, vy, vz, tag)
   USE IonParticles, ONLY : Qs
   USE CurrentProblemValues, ONLY : whole_object, VACUUM_GAP, METAL_WALL, DIELECTRIC
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER errcode,ierr
 
@@ -88,9 +88,9 @@ SUBROUTINE PROCESS_ION_COLL_WITH_BOUNDARY_RIGHT(s, x, y, vx, vy, vz, tag)
   USE IonParticles, ONLY : Qs
   USE CurrentProblemValues, ONLY : whole_object, VACUUM_GAP, METAL_WALL, DIELECTRIC
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER errcode,ierr
 
@@ -167,11 +167,11 @@ SUBROUTINE PROCESS_ION_COLL_WITH_BOUNDARY_BELOW(s, x, y, vx, vy, vz, tag)
   USE ParallelOperationValues
   USE ClusterAndItsBoundaries
   USE IonParticles, ONLY : Qs
-   USE CurrentProblemValues, ONLY : whole_object, VACUUM_GAP, METAL_WALL, DIELECTRIC
+  USE CurrentProblemValues, ONLY : whole_object, VACUUM_GAP, METAL_WALL, DIELECTRIC
+
+  use mpi
 
   IMPLICIT NONE
-
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
 
@@ -250,9 +250,9 @@ SUBROUTINE PROCESS_ION_COLL_WITH_BOUNDARY_ABOVE(s, x, y, vx, vy, vz, tag)
   USE IonParticles, ONLY : Qs
   USE CurrentProblemValues, ONLY : whole_object, VACUUM_GAP, METAL_WALL, DIELECTRIC
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER errcode,ierr
 
@@ -331,9 +331,9 @@ SUBROUTINE COLLECT_PARTICLE_BOUNDARY_HITS
   USE ClusterAndItsBoundaries
   USE IonParticles, ONLY : N_spec
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER errcode,ierr
 !  INTEGER stattus(MPI_STATUS_SIZE)
@@ -399,9 +399,9 @@ SUBROUTINE TRY_ION_COLL_WITH_INNER_OBJECT(s, x, y, vx, vy, vz, tag)
   USE IonParticles, ONLY : Qs
   USE CurrentProblemValues !, ONLY : inner_object, METAL_WALL, DIELECTRIC
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER errcode,ierr
 
@@ -587,9 +587,9 @@ SUBROUTINE GATHER_SURFACE_CHARGE_DENSITY
   USE CurrentProblemValues
   USE ClusterAndItsBoundaries  
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER errcode,ierr
   INTEGER stattus(MPI_STATUS_SIZE)
@@ -738,7 +738,7 @@ SUBROUTINE GATHER_SURFACE_CHARGE_DENSITY
               c_local_object_part(n_right(n))%surface_charge(c_indx_x_max) = 0.0_8
            END IF
         END DO
-        CALL MPI_SEND(rbufer(1:2), 2, MPI_DOUBLE_PRECISION, Rank_of_master_right, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(rbufer(1:2), 2, MPI_DOUBLE_PRECISION, Rank_of_master_right, Rank_of_process, MPI_COMM_WORLD, ierr) 
      END IF
 
      IF (connect_left) THEN
@@ -750,7 +750,7 @@ SUBROUTINE GATHER_SURFACE_CHARGE_DENSITY
               c_local_object_part(n_left(n))%surface_charge(c_indx_x_min) = 0.0_8
            END IF
         END DO
-        CALL MPI_SEND(rbufer(1:2), 2, MPI_DOUBLE_PRECISION, Rank_of_master_left, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(rbufer(1:2), 2, MPI_DOUBLE_PRECISION, Rank_of_master_left, Rank_of_process, MPI_COMM_WORLD, ierr) 
      END IF
 
      IF (connect_left) THEN
@@ -784,7 +784,7 @@ SUBROUTINE GATHER_SURFACE_CHARGE_DENSITY
               c_local_object_part(n_above(n))%surface_charge(c_indx_y_max) = 0.0_8
            END IF
         END DO
-        CALL MPI_SEND(rbufer(1:2), 2, MPI_DOUBLE_PRECISION, Rank_of_master_above, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(rbufer(1:2), 2, MPI_DOUBLE_PRECISION, Rank_of_master_above, Rank_of_process, MPI_COMM_WORLD, ierr) 
      END IF
 
      IF (connect_below) THEN
@@ -796,7 +796,7 @@ SUBROUTINE GATHER_SURFACE_CHARGE_DENSITY
               c_local_object_part(n_below(n))%surface_charge(c_indx_y_min) = 0.0_8
            END IF
         END DO
-        CALL MPI_SEND(rbufer(1:2), 2, MPI_DOUBLE_PRECISION, Rank_of_master_below, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(rbufer(1:2), 2, MPI_DOUBLE_PRECISION, Rank_of_master_below, Rank_of_process, MPI_COMM_WORLD, ierr) 
      END IF
 
      IF (connect_below) THEN
@@ -853,7 +853,7 @@ SUBROUTINE GATHER_SURFACE_CHARGE_DENSITY
               c_local_object_part(n_right(n))%surface_charge(c_indx_x_max) = 0.0_8
            END IF
         END DO
-        CALL MPI_SEND(rbufer(1:2), 2, MPI_DOUBLE_PRECISION, Rank_of_master_right, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(rbufer(1:2), 2, MPI_DOUBLE_PRECISION, Rank_of_master_right, Rank_of_process, MPI_COMM_WORLD, ierr) 
      END IF
 
      IF (connect_left) THEN
@@ -865,7 +865,7 @@ SUBROUTINE GATHER_SURFACE_CHARGE_DENSITY
               c_local_object_part(n_left(n))%surface_charge(c_indx_x_min) = 0.0_8
            END IF
         END DO
-        CALL MPI_SEND(rbufer(1:2), 2, MPI_DOUBLE_PRECISION, Rank_of_master_left, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(rbufer(1:2), 2, MPI_DOUBLE_PRECISION, Rank_of_master_left, Rank_of_process, MPI_COMM_WORLD, ierr) 
      END IF
 
      IF (connect_below) THEN
@@ -897,7 +897,7 @@ SUBROUTINE GATHER_SURFACE_CHARGE_DENSITY
               c_local_object_part(n_above(n))%surface_charge(c_indx_y_max) = 0.0_8
            END IF
         END DO
-        CALL MPI_SEND(rbufer(1:2), 2, MPI_DOUBLE_PRECISION, Rank_of_master_above, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(rbufer(1:2), 2, MPI_DOUBLE_PRECISION, Rank_of_master_above, Rank_of_process, MPI_COMM_WORLD, ierr) 
      END IF
 
      IF (connect_below) THEN
@@ -909,7 +909,7 @@ SUBROUTINE GATHER_SURFACE_CHARGE_DENSITY
               c_local_object_part(n_below(n))%surface_charge(c_indx_y_min) = 0.0_8
            END IF
         END DO
-        CALL MPI_SEND(rbufer(1:2), 2, MPI_DOUBLE_PRECISION, Rank_of_master_below, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+        CALL MPI_SEND(rbufer(1:2), 2, MPI_DOUBLE_PRECISION, Rank_of_master_below, Rank_of_process, MPI_COMM_WORLD, ierr) 
      END IF
 
   END IF
@@ -927,9 +927,9 @@ SUBROUTINE GATHER_SURFACE_CHARGE_DENSITY_INNER_OBJECTS
   USE CurrentProblemValues
   USE ClusterAndItsBoundaries  
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER errcode,ierr
 

--- a/src/pic2d_LoadBalancing.f90
+++ b/src/pic2d_LoadBalancing.f90
@@ -9,10 +9,9 @@ SUBROUTINE GLOBAL_LOAD_BALANCE
   USE CurrentProblemValues, ONLY : N_subcycles
 
   USE ClusterAndItsBoundaries
+  use mpi
  
   IMPLICIT NONE
-
-  INCLUDE 'mpif.h'
 
 ! these variables are used to print ranks of processes in cluster communicator
   integer clustergroup, worldgroup
@@ -99,7 +98,7 @@ SUBROUTINE GLOBAL_LOAD_BALANCE
         END DO
 ! send messages to other masters about the changes in the number of processes
         DO m = 1, N_processes_horizontal-1
-           CALL MPI_SEND(cluster(m)%N_processes-cluster(m)%N_processes_balanced, 1, MPI_INTEGER, m, 0, COMM_HORIZONTAL, request, ierr)            
+           CALL MPI_SEND(cluster(m)%N_processes-cluster(m)%N_processes_balanced, 1, MPI_INTEGER, m, 0, COMM_HORIZONTAL, ierr)            
         END DO
 ! prepare messages to masters of clusters that will be releasing processes containing values of particle_master for the new cluster of these processes
         i = 0
@@ -118,7 +117,7 @@ SUBROUTINE GLOBAL_LOAD_BALANCE
            IF (delta_N.GT.0) THEN
               pos_begin = pos_end + 1
               pos_end = pos_begin + delta_N - 1
-              CALL MPI_SEND(free_process_new_master(pos_begin:pos_end), delta_N, MPI_INTEGER, m, SHIFT1, COMM_HORIZONTAL, request, ierr)
+              CALL MPI_SEND(free_process_new_master(pos_begin:pos_end), delta_N, MPI_INTEGER, m, SHIFT1, COMM_HORIZONTAL, ierr)
            END IF
         END DO
 ! update the cluster information
@@ -251,7 +250,7 @@ print '("MASTER MESSAGE :: Rank_of_process ",i4," Rank_cluster ",i4," particle_m
         ALLOCATE(ibufer(0:N_spec), STAT=ALLOC_ERR)
         ibufer(0) = N_electrons
         ibufer(1:N_spec) = N_ions(1:N_spec)
-        CALL MPI_SEND(ibufer(0:N_spec), N_spec+1, MPI_INTEGER, 0, 0, COMM_CLUSTER, request, ierr) 
+        CALL MPI_SEND(ibufer(0:N_spec), N_spec+1, MPI_INTEGER, 0, 0, COMM_CLUSTER, ierr) 
         DEALLOCATE(ibufer, STAT=ALLOC_ERR)
         sum_N_part_to_send = N_electrons
         DO s = 1, N_spec
@@ -284,7 +283,7 @@ print '("MASTER MESSAGE :: Rank_of_process ",i4," Rank_cluster ",i4," particle_m
               END DO
            END DO
 ! send particles
-           CALL MPI_SEND(rbufer, sum_N_part_to_send*6, MPI_DOUBLE_PRECISION, 0, Rank_cluster, COMM_CLUSTER, request, ierr)     
+           CALL MPI_SEND(rbufer, sum_N_part_to_send*6, MPI_DOUBLE_PRECISION, 0, Rank_cluster, COMM_CLUSTER, ierr)     
            DEALLOCATE(rbufer, STAT=ALLOC_ERR)
         END IF
 ! clear the counters
@@ -348,9 +347,9 @@ SUBROUTINE CALCULATE_N_PROCESSES_BALANCED(N_of_all_free_processes)
   USE ParallelOperationValues  
   USE LoadBalancing
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER errcode,ierr
 
@@ -556,9 +555,9 @@ SUBROUTINE BALANCE_LOAD_WITHIN_CLUSTER
   USE ElectronParticles
   USE IonParticles
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER errcode,ierr
   INTEGER stattus(MPI_STATUS_SIZE)

--- a/src/pic2d_MainProgram.f90
+++ b/src/pic2d_MainProgram.f90
@@ -7,9 +7,10 @@ PROGRAM MainProg
   USE ClusterAndItsBoundaries
   USE Checkpoints
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
   REAL(8) start, finish

--- a/src/pic2d_PETSc_Solver.F90
+++ b/src/pic2d_PETSc_Solver.F90
@@ -1493,6 +1493,8 @@ SUBROUTINE FIND_INNER_OBJECT_CONTAINING_POINT(i, j, nio, position_flag)
 
   USE CurrentProblemValues
 
+  use mpi
+
   IMPLICIT NONE
 
   INTEGER, INTENT(IN) ::  i, j  ! x,y indices of the point of interest
@@ -1575,6 +1577,8 @@ SUBROUTINE CHECK_IF_INNER_OBJECT_CONTAINS_POINT(myobject, i, j, position_flag)
 
   USE CurrentProblemValues
 
+  use mpi
+
   IMPLICIT NONE
 
   TYPE(boundary_object), INTENT(IN) :: myobject
@@ -1645,9 +1649,10 @@ END SUBROUTINE CHECK_IF_INNER_OBJECT_CONTAINS_POINT
 REAL(8) FUNCTION Get_Surface_Charge_Inner_Object(i,j,position_flag, myobject)
 
   USE CurrentProblemValues
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
  
@@ -1726,9 +1731,10 @@ SUBROUTINE SET_EPS_ISHIFTED(i, j, eps)  ! here point {i,j} is between nodes {i-1
 
   USE CurrentProblemValues
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
  
@@ -1890,9 +1896,10 @@ SUBROUTINE SET_EPS_JSHIFTED(i, j, eps)  ! here point {i,j} is between nodes {i,j
 
   USE CurrentProblemValues
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
  
@@ -2055,9 +2062,10 @@ SUBROUTINE GET_EPS_IN_POINT(x, y, eps)
 
   USE CurrentProblemValues
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
  

--- a/src/pic2d_ParticleExchange.f90
+++ b/src/pic2d_ParticleExchange.f90
@@ -7,9 +7,9 @@ SUBROUTINE EXCHANGE_PARTICLES_WITH_LEFT_RIGHT_NEIGHBOURS
   USE IonParticles
   USE ClusterAndItsBoundaries, ONLY : c_X_area_min, c_X_area_max, c_Y_area_min, c_Y_area_max
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER total_part_number_to_receive(0:N_spec)
   INTEGER n
@@ -169,7 +169,7 @@ SUBROUTINE EXCHANGE_PARTICLES_WITH_LEFT_RIGHT_NEIGHBOURS
 ! send the number of particles
         ibufer(0) = N_e_to_send_right
         ibufer(1:N_spec) = N_ions_to_send_right(1:N_spec)
-        CALL MPI_SEND(ibufer(0:N_spec), N_spec+1, MPI_INTEGER, MOD(Rank_cluster,N_processes_cluster_right), 0, COMM_CLUSTER, request, ierr) 
+        CALL MPI_SEND(ibufer(0:N_spec), N_spec+1, MPI_INTEGER, MOD(Rank_cluster,N_processes_cluster_right), 0, COMM_CLUSTER, ierr) 
         sum_N_part_to_send = N_e_to_send_right
         DO s = 1, N_spec
            sum_N_part_to_send = sum_N_part_to_send + N_ions_to_send_right(s)
@@ -201,7 +201,7 @@ SUBROUTINE EXCHANGE_PARTICLES_WITH_LEFT_RIGHT_NEIGHBOURS
               END DO
            END DO
 ! send particles
-           CALL MPI_SEND(rbufer, sum_N_part_to_send*6, MPI_DOUBLE_PRECISION, MOD(Rank_cluster,N_processes_cluster_right), Rank_cluster, COMM_CLUSTER, request, ierr)     
+           CALL MPI_SEND(rbufer, sum_N_part_to_send*6, MPI_DOUBLE_PRECISION, MOD(Rank_cluster,N_processes_cluster_right), Rank_cluster, COMM_CLUSTER, ierr)     
 ! clear the counters
            N_e_to_send_right = 0
            N_ions_to_send_right = 0
@@ -346,7 +346,7 @@ SUBROUTINE EXCHANGE_PARTICLES_WITH_LEFT_RIGHT_NEIGHBOURS
 ! send the number of particles
         ibufer(0) = N_e_to_send_left
         ibufer(1:N_spec) = N_ions_to_send_left(1:N_spec)
-        CALL MPI_SEND(ibufer(0:N_spec), N_spec+1, MPI_INTEGER, MOD(Rank_cluster,N_processes_cluster_left), 0, COMM_CLUSTER, request, ierr) 
+        CALL MPI_SEND(ibufer(0:N_spec), N_spec+1, MPI_INTEGER, MOD(Rank_cluster,N_processes_cluster_left), 0, COMM_CLUSTER, ierr) 
         sum_N_part_to_send = N_e_to_send_left
         DO s = 1, N_spec
            sum_N_part_to_send = sum_N_part_to_send + N_ions_to_send_left(s)
@@ -378,7 +378,7 @@ SUBROUTINE EXCHANGE_PARTICLES_WITH_LEFT_RIGHT_NEIGHBOURS
               END DO
            END DO
 ! send particles
-           CALL MPI_SEND(rbufer, sum_N_part_to_send*6, MPI_DOUBLE_PRECISION, MOD(Rank_cluster,N_processes_cluster_left), Rank_cluster, COMM_CLUSTER, request, ierr)     
+           CALL MPI_SEND(rbufer, sum_N_part_to_send*6, MPI_DOUBLE_PRECISION, MOD(Rank_cluster,N_processes_cluster_left), Rank_cluster, COMM_CLUSTER, ierr)     
 ! clear the counter
            N_e_to_send_left = 0
            N_ions_to_send_left = 0
@@ -403,7 +403,7 @@ SUBROUTINE EXCHANGE_PARTICLES_WITH_LEFT_RIGHT_NEIGHBOURS
            sum_N_part_to_send = sum_N_part_to_send + N_ions_to_send_right(s)
         END DO
         
-        CALL MPI_SEND(ibufer, N_spec+1, MPI_INTEGER, Rank_horizontal_right, 0, COMM_HORIZONTAL, request, ierr) 
+        CALL MPI_SEND(ibufer, N_spec+1, MPI_INTEGER, Rank_horizontal_right, 0, COMM_HORIZONTAL, ierr) 
 
 ! ##  2 ## send right the particles
         IF (sum_N_part_to_send.GT.0) THEN
@@ -432,7 +432,7 @@ SUBROUTINE EXCHANGE_PARTICLES_WITH_LEFT_RIGHT_NEIGHBOURS
               END DO
            END DO
 ! send particles to right neighbor
-           CALL MPI_SEND(rbufer, sum_N_part_to_send*6, MPI_DOUBLE_PRECISION, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, request, ierr)     
+           CALL MPI_SEND(rbufer, sum_N_part_to_send*6, MPI_DOUBLE_PRECISION, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, ierr)     
 ! clear the counters
            N_e_to_send_right = 0
            N_ions_to_send_right = 0
@@ -452,7 +452,7 @@ SUBROUTINE EXCHANGE_PARTICLES_WITH_LEFT_RIGHT_NEIGHBOURS
            sum_N_part_to_send = sum_N_part_to_send + N_ions_to_send_left(s)
         END DO
         
-        CALL MPI_SEND(ibufer, N_spec+1, MPI_INTEGER, Rank_horizontal_left, 0, COMM_HORIZONTAL, request, ierr) 
+        CALL MPI_SEND(ibufer, N_spec+1, MPI_INTEGER, Rank_horizontal_left, 0, COMM_HORIZONTAL, ierr) 
 
 ! ##  4 ## send left the particles
         IF (sum_N_part_to_send.GT.0) THEN
@@ -482,7 +482,7 @@ SUBROUTINE EXCHANGE_PARTICLES_WITH_LEFT_RIGHT_NEIGHBOURS
               END DO
            END DO
 ! send particles to left neighbor
-           CALL MPI_SEND(rbufer, sum_N_part_to_send*6, MPI_DOUBLE_PRECISION, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, request, ierr)     
+           CALL MPI_SEND(rbufer, sum_N_part_to_send*6, MPI_DOUBLE_PRECISION, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, ierr)     
 ! clear the counters
            N_e_to_send_left = 0
            N_ions_to_send_left = 0
@@ -793,7 +793,7 @@ SUBROUTINE EXCHANGE_PARTICLES_WITH_LEFT_RIGHT_NEIGHBOURS
            sum_N_part_to_send = sum_N_part_to_send + N_ions_to_send_right(s)
         END DO
         
-        CALL MPI_SEND(ibufer, N_spec+1, MPI_INTEGER, Rank_horizontal_right, 0, COMM_HORIZONTAL, request, ierr) 
+        CALL MPI_SEND(ibufer, N_spec+1, MPI_INTEGER, Rank_horizontal_right, 0, COMM_HORIZONTAL, ierr) 
 
 ! ##  6 ## send right the particles
         IF (sum_N_part_to_send.GT.0) THEN
@@ -822,7 +822,7 @@ SUBROUTINE EXCHANGE_PARTICLES_WITH_LEFT_RIGHT_NEIGHBOURS
               END DO
            END DO
 ! send particles to right neighbor
-           CALL MPI_SEND(rbufer, sum_N_part_to_send*6, MPI_DOUBLE_PRECISION, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, request, ierr)     
+           CALL MPI_SEND(rbufer, sum_N_part_to_send*6, MPI_DOUBLE_PRECISION, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, ierr)     
 ! clear the counters
            N_e_to_send_right = 0
            N_ions_to_send_right = 0
@@ -840,7 +840,7 @@ SUBROUTINE EXCHANGE_PARTICLES_WITH_LEFT_RIGHT_NEIGHBOURS
            sum_N_part_to_send = sum_N_part_to_send + N_ions_to_send_left(s)
         END DO
         
-        CALL MPI_SEND(ibufer, N_spec+1, MPI_INTEGER, Rank_horizontal_left, 0, COMM_HORIZONTAL, request, ierr) 
+        CALL MPI_SEND(ibufer, N_spec+1, MPI_INTEGER, Rank_horizontal_left, 0, COMM_HORIZONTAL, ierr) 
 
 ! ##  8 ## send left the particles
         IF (sum_N_part_to_send.GT.0) THEN
@@ -870,7 +870,7 @@ SUBROUTINE EXCHANGE_PARTICLES_WITH_LEFT_RIGHT_NEIGHBOURS
               END DO
            END DO
 ! send particles to left neighbor
-           CALL MPI_SEND(rbufer, sum_N_part_to_send*6, MPI_DOUBLE_PRECISION, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, request, ierr)     
+           CALL MPI_SEND(rbufer, sum_N_part_to_send*6, MPI_DOUBLE_PRECISION, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, ierr)     
 ! clear the counters
            N_e_to_send_left = 0
            N_ions_to_send_left = 0
@@ -895,9 +895,9 @@ SUBROUTINE EXCHANGE_PARTICLES_WITH_ABOVE_BELOW_NEIGHBOURS
   USE IonParticles
   USE ClusterAndItsBoundaries, ONLY : c_X_area_min, c_X_area_max, c_Y_area_min, c_Y_area_max
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER total_part_number_to_receive(0:N_spec)
   INTEGER n
@@ -1056,7 +1056,7 @@ SUBROUTINE EXCHANGE_PARTICLES_WITH_ABOVE_BELOW_NEIGHBOURS
 ! send the number of particles
         ibufer(0) = N_e_to_send_above
         ibufer(1:N_spec) = N_ions_to_send_above(1:N_spec)
-        CALL MPI_SEND(ibufer(0:N_spec), N_spec+1, MPI_INTEGER, MOD(Rank_cluster,N_processes_cluster_above), 0, COMM_CLUSTER, request, ierr) 
+        CALL MPI_SEND(ibufer(0:N_spec), N_spec+1, MPI_INTEGER, MOD(Rank_cluster,N_processes_cluster_above), 0, COMM_CLUSTER, ierr) 
         sum_N_part_to_send = N_e_to_send_above
         DO s = 1, N_spec
            sum_N_part_to_send = sum_N_part_to_send + N_ions_to_send_above(s)
@@ -1088,7 +1088,7 @@ SUBROUTINE EXCHANGE_PARTICLES_WITH_ABOVE_BELOW_NEIGHBOURS
               END DO
            END DO
 ! send particles
-           CALL MPI_SEND(rbufer, sum_N_part_to_send*6, MPI_DOUBLE_PRECISION, MOD(Rank_cluster,N_processes_cluster_above), Rank_cluster, COMM_CLUSTER, request, ierr)     
+           CALL MPI_SEND(rbufer, sum_N_part_to_send*6, MPI_DOUBLE_PRECISION, MOD(Rank_cluster,N_processes_cluster_above), Rank_cluster, COMM_CLUSTER, ierr)     
 ! clear the counters
            N_e_to_send_above = 0
            N_ions_to_send_above = 0
@@ -1233,7 +1233,7 @@ SUBROUTINE EXCHANGE_PARTICLES_WITH_ABOVE_BELOW_NEIGHBOURS
 ! send the number of particles
         ibufer(0) = N_e_to_send_below
         ibufer(1:N_spec) = N_ions_to_send_below(1:N_spec)
-        CALL MPI_SEND(ibufer(0:N_spec), N_spec+1, MPI_INTEGER, MOD(Rank_cluster,N_processes_cluster_below), 0, COMM_CLUSTER, request, ierr) 
+        CALL MPI_SEND(ibufer(0:N_spec), N_spec+1, MPI_INTEGER, MOD(Rank_cluster,N_processes_cluster_below), 0, COMM_CLUSTER, ierr) 
         sum_N_part_to_send = N_e_to_send_below
         DO s = 1, N_spec
            sum_N_part_to_send = sum_N_part_to_send + N_ions_to_send_below(s)
@@ -1265,7 +1265,7 @@ SUBROUTINE EXCHANGE_PARTICLES_WITH_ABOVE_BELOW_NEIGHBOURS
               END DO
            END DO
 ! send particles
-           CALL MPI_SEND(rbufer, sum_N_part_to_send*6, MPI_DOUBLE_PRECISION, MOD(Rank_cluster,N_processes_cluster_below), Rank_cluster, COMM_CLUSTER, request, ierr)     
+           CALL MPI_SEND(rbufer, sum_N_part_to_send*6, MPI_DOUBLE_PRECISION, MOD(Rank_cluster,N_processes_cluster_below), Rank_cluster, COMM_CLUSTER, ierr)     
 ! clear the counters
            N_e_to_send_below = 0
            N_ions_to_send_below = 0
@@ -1290,7 +1290,7 @@ SUBROUTINE EXCHANGE_PARTICLES_WITH_ABOVE_BELOW_NEIGHBOURS
            sum_N_part_to_send = sum_N_part_to_send + N_ions_to_send_above(s)
         END DO
         
-        CALL MPI_SEND(ibufer, N_spec+1, MPI_INTEGER, Rank_horizontal_above, 0, COMM_HORIZONTAL, request, ierr) 
+        CALL MPI_SEND(ibufer, N_spec+1, MPI_INTEGER, Rank_horizontal_above, 0, COMM_HORIZONTAL, ierr) 
 
 ! ## 10 ## send up the particles
         IF (sum_N_part_to_send.GT.0) THEN
@@ -1319,7 +1319,7 @@ SUBROUTINE EXCHANGE_PARTICLES_WITH_ABOVE_BELOW_NEIGHBOURS
               END DO
            END DO
 ! send particles to neighbor above
-           CALL MPI_SEND(rbufer, sum_N_part_to_send*6, MPI_DOUBLE_PRECISION, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, request, ierr)     
+           CALL MPI_SEND(rbufer, sum_N_part_to_send*6, MPI_DOUBLE_PRECISION, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, ierr)     
 ! clear the counters
            N_e_to_send_above = 0
            N_ions_to_send_above = 0
@@ -1337,7 +1337,7 @@ SUBROUTINE EXCHANGE_PARTICLES_WITH_ABOVE_BELOW_NEIGHBOURS
            sum_N_part_to_send = sum_N_part_to_send + N_ions_to_send_below(s)
         END DO
         
-        CALL MPI_SEND(ibufer, N_spec+1, MPI_INTEGER, Rank_horizontal_below, 0, COMM_HORIZONTAL, request, ierr) 
+        CALL MPI_SEND(ibufer, N_spec+1, MPI_INTEGER, Rank_horizontal_below, 0, COMM_HORIZONTAL, ierr) 
 
 ! ## 12 ## send down the particles
         IF (sum_N_part_to_send.GT.0) THEN
@@ -1366,7 +1366,7 @@ SUBROUTINE EXCHANGE_PARTICLES_WITH_ABOVE_BELOW_NEIGHBOURS
               END DO
            END DO
 ! send particles to neighbor below
-           CALL MPI_SEND(rbufer, sum_N_part_to_send*6, MPI_DOUBLE_PRECISION, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, request, ierr)     
+           CALL MPI_SEND(rbufer, sum_N_part_to_send*6, MPI_DOUBLE_PRECISION, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, ierr)     
 ! clear the counters
            N_e_to_send_below = 0
            N_ions_to_send_below = 0
@@ -1671,7 +1671,7 @@ SUBROUTINE EXCHANGE_PARTICLES_WITH_ABOVE_BELOW_NEIGHBOURS
            sum_N_part_to_send = sum_N_part_to_send + N_ions_to_send_above(s)
         END DO
         
-        CALL MPI_SEND(ibufer, N_spec+1, MPI_INTEGER, Rank_horizontal_above, 0, COMM_HORIZONTAL, request, ierr) 
+        CALL MPI_SEND(ibufer, N_spec+1, MPI_INTEGER, Rank_horizontal_above, 0, COMM_HORIZONTAL, ierr) 
 
 ! ## 14 ## send up the particles
         IF (sum_N_part_to_send.GT.0) THEN
@@ -1700,7 +1700,7 @@ SUBROUTINE EXCHANGE_PARTICLES_WITH_ABOVE_BELOW_NEIGHBOURS
               END DO
            END DO
 ! send particles to neighbor above
-           CALL MPI_SEND(rbufer, sum_N_part_to_send*6, MPI_DOUBLE_PRECISION, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, request, ierr)     
+           CALL MPI_SEND(rbufer, sum_N_part_to_send*6, MPI_DOUBLE_PRECISION, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, ierr)     
 ! clear the counters
            N_e_to_send_above = 0
            N_ions_to_send_above = 0
@@ -1718,7 +1718,7 @@ SUBROUTINE EXCHANGE_PARTICLES_WITH_ABOVE_BELOW_NEIGHBOURS
            sum_N_part_to_send = sum_N_part_to_send + N_ions_to_send_below(s)
         END DO
         
-        CALL MPI_SEND(ibufer, N_spec+1, MPI_INTEGER, Rank_horizontal_below, 0, COMM_HORIZONTAL, request, ierr) 
+        CALL MPI_SEND(ibufer, N_spec+1, MPI_INTEGER, Rank_horizontal_below, 0, COMM_HORIZONTAL, ierr) 
 
 ! ## 16 ## send down the particles
         IF (sum_N_part_to_send.GT.0) THEN
@@ -1747,7 +1747,7 @@ SUBROUTINE EXCHANGE_PARTICLES_WITH_ABOVE_BELOW_NEIGHBOURS
               END DO
            END DO
 ! send particles to neighbor below
-           CALL MPI_SEND(rbufer, sum_N_part_to_send*6, MPI_DOUBLE_PRECISION, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, request, ierr)     
+           CALL MPI_SEND(rbufer, sum_N_part_to_send*6, MPI_DOUBLE_PRECISION, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, ierr)     
 ! clear the counters
            N_e_to_send_below = 0
            N_ions_to_send_below = 0

--- a/src/pic2d_Prepare_FFTX_SYSY.f90
+++ b/src/pic2d_Prepare_FFTX_SYSY.f90
@@ -9,9 +9,10 @@ SUBROUTINE PREPARE_FFT_X
   USE ParallelFFTX
   USE ParallelOperationValues, ONLY : Rank_of_process, cluster_rank_key
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
 
@@ -334,9 +335,10 @@ SUBROUTINE PREPARE_SYS_Y
   USE ParallelFFTX
   USE SetupValues, ONLY : ht_grid_requested, grid_j
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
   INTEGER stattus(MPI_STATUS_SIZE)
@@ -592,7 +594,7 @@ SUBROUTINE PREPARE_SYS_Y
            ibufer(5) = field_calculator(k)%sysy_strip_nmin
            ibufer(6) = field_calculator(k)%sysy_strip_nmax
 
-           CALL MPI_SEND(ibufer, 6, MPI_INTEGER, field_calculator(k)%rank, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+           CALL MPI_SEND(ibufer, 6, MPI_INTEGER, field_calculator(k)%rank, Rank_of_process, MPI_COMM_WORLD, ierr) 
         END DO
 
      END IF

--- a/src/pic2d_SEEmission.f90
+++ b/src/pic2d_SEEmission.f90
@@ -8,9 +8,10 @@ SUBROUTINE PROCESS_ELECTRON_INDUCED_ELECTRON_EMISSION(x, y, vx, vy, vz, tag, myo
 
   USE rng_wrapper
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
 
@@ -160,6 +161,8 @@ SUBROUTINE INJECT_ELASTIC_REFLECTED_ELECTRON(x, y, vx, vy, vz, v, tag, myobject,
   USE CurrentProblemValues
 
   USE rng_wrapper
+
+  use mpi
 
   IMPLICIT NONE
 
@@ -567,6 +570,8 @@ SUBROUTINE INJECT_INELASTIC_BACKSCATTERED_ELECTRON(x, y, v, tag, myobject, m, di
 
   USE rng_wrapper
 
+  use mpi
+
   IMPLICIT NONE
 
   REAL(8) x, y         ! primary electron coordinates
@@ -799,6 +804,8 @@ SUBROUTINE INJECT_TRUE_SECONDARY_ELECTRON(x, y, energy_inc, tag, myobject, m, di
   USE CurrentProblemValues
 
   USE rng_wrapper
+
+  use mpi
 
   IMPLICIT NONE
 
@@ -1055,6 +1062,8 @@ END SUBROUTINE INJECT_TRUE_SECONDARY_ELECTRON
 REAL(8) FUNCTION Coeff_SEE_Elastic(energy, theta, myobject)
 
   USE CurrentProblemValues !, ONLY : whole_object
+  use mpi
+
   IMPLICIT NONE
 
   REAL(8) energy       ! dim-less energy of incident electron
@@ -1104,6 +1113,8 @@ END FUNCTION Coeff_SEE_Elastic
 REAL(8) FUNCTION Coeff_SEE_Inelastic(energy, theta, myobject)
 
   USE CurrentProblemValues !, ONLY : whole_object
+  use mpi
+
   IMPLICIT NONE
 
   REAL(8) energy       ! dim-less energy of incident electron
@@ -1140,6 +1151,8 @@ END FUNCTION Coeff_SEE_Inelastic
 REAL(8) FUNCTION Coeff_SEE_True(energy, theta, myobject)
 
   USE CurrentProblemValues !, ONLY : whole_object
+  use mpi
+
   IMPLICIT NONE
 
   REAL(8) energy       ! dim-less energy of incident electron
@@ -1172,6 +1185,8 @@ END FUNCTION Coeff_SEE_True
 REAL(8) FUNCTION Coeff_SEE_Classic(energy, theta, myobject)
 
   USE CurrentProblemValues !, ONLY : whole_object
+  use mpi
+
   IMPLICIT NONE
 
   REAL(8) energy       ! dim-less energy of incident electron

--- a/src/pic2d_Setup.f90
+++ b/src/pic2d_Setup.f90
@@ -5,9 +5,10 @@ SUBROUTINE PREPARE_SETUP_VALUES
   USE ParallelOperationValues
   USE CurrentProblemValues
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
 
@@ -153,6 +154,8 @@ SUBROUTINE PREPARE_WAVEFORMS
   USE ParallelOperationValues, ONLY : Rank_of_process
   USE CurrentProblemValues, ONLY : whole_object, N_of_boundary_and_inner_objects, METAL_WALL, delta_t_s, F_scale_V
 
+  use mpi
+
   IMPLICIT NONE
 
   INTEGER n
@@ -275,6 +278,8 @@ SUBROUTINE PREPARE_OSCILLATIONS_AMPLITUDE_PROFILE
 
   USE ParallelOperationValues, ONLY : Rank_of_process
   USE CurrentProblemValues, ONLY : whole_object, N_of_boundary_and_inner_objects, METAL_WALL, delta_t_s
+
+  use mpi
 
   IMPLICIT NONE
 
@@ -421,6 +426,8 @@ SUBROUTINE PREPARE_EXTERNAL_CIRCUIT
   USE CurrentProblemValues, ONLY : whole_object, N_of_boundary_and_inner_objects, METAL_WALL, delta_t_s, F_scale_V, pi
   USE BlockAndItsBoundaries
 
+  use mpi
+
   IMPLICIT NONE
 
   LOGICAL exists
@@ -560,6 +567,8 @@ SUBROUTINE INITIATE_EXT_CIRCUIT_DIAGNOSTICS
   USE SetupValues, ONLY : ht_use_e_emission_from_cathode, ht_use_e_emission_from_cathode_zerogradf, ht_emission_constant
   USE ExternalCircuit, ONLY : N_of_object_potentials_to_solve
 
+  use mpi
+
   IMPLICIT NONE
 
   LOGICAL exists
@@ -606,9 +615,10 @@ SUBROUTINE PERFORM_ELECTRON_EMISSION_SETUP
 
   USE rng_wrapper
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER ierr
 
@@ -1012,9 +1022,10 @@ SUBROUTINE PERFORM_ELECTRON_EMISSION_SETUP_INNER_OBJECTS
 
   USE rng_wrapper
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
 

--- a/src/pic2d_Snapshots.f90
+++ b/src/pic2d_Snapshots.f90
@@ -11,9 +11,9 @@ SUBROUTINE INITIATE_SNAPSHOTS
   USE MCCollisions
   USE ClusterAndItsBoundaries
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER ierr
 
@@ -312,9 +312,9 @@ SUBROUTINE CREATE_SNAPSHOT
   USE IonParticles, ONLY : N_spec, Qs, Ms
   USE MCCollisions
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER ierr
   INTEGER stattus(MPI_STATUS_SIZE)
@@ -436,7 +436,7 @@ SUBROUTINE CREATE_SNAPSHOT
               pos1 = pos1 + recsize
            END DO
 
-           CALL MPI_SEND(rbufer, bufsize, MPI_REAL, field_master, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+           CALL MPI_SEND(rbufer, bufsize, MPI_REAL, field_master, Rank_of_process, MPI_COMM_WORLD, ierr) 
 
            DEALLOCATE(rbufer, STAT = ALLOC_ERR)
         
@@ -1214,9 +1214,9 @@ SUBROUTINE SAVE_GLOBAL_2D_ARRAY(arr, filename)
   USE IonParticles
   USE Snapshots
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   REAL arr(c_indx_x_min:c_indx_x_max, c_indx_y_min:c_indx_y_max)
 
@@ -1367,9 +1367,9 @@ SUBROUTINE SAVE_ALL_VDF1D
   USE IonParticles
   USE Snapshots
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   CHARACTER(15) filename      ! _NNNN_vdf1d.bin
                               ! ----x----I----x
@@ -1556,9 +1556,9 @@ SUBROUTINE SAVE_ALL_VDF2D
   USE IonParticles
   USE Snapshots
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   CHARACTER(15) filename      ! _NNNN_vdf2d.bin
                               ! ----x----I----x
@@ -1715,10 +1715,10 @@ SUBROUTINE SAVE_ELECTRON_PHASE_PLANES
   USE CurrentProblemValues
   USE ElectronParticles
   USE Snapshots
+
+  use mpi
   
   IMPLICIT NONE
-
-  INCLUDE 'mpif.h'
 
   INTEGER ierr
   INTEGER stattus(MPI_STATUS_SIZE)
@@ -1853,10 +1853,10 @@ SUBROUTINE SAVE_ION_PHASE_PLANES
   USE CurrentProblemValues
   USE IonParticles
   USE Snapshots
+
+  use mpi
   
   IMPLICIT NONE
-
-  INCLUDE 'mpif.h'
 
   INTEGER ierr
   INTEGER stattus(MPI_STATUS_SIZE)
@@ -2004,9 +2004,9 @@ SUBROUTINE SAVE_en_COLLISIONS_2D
   USE MCCollisions
   USE Snapshots
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER ierr
   INTEGER stattus(MPI_STATUS_SIZE)
@@ -2073,13 +2073,13 @@ SUBROUTINE SAVE_en_COLLISIONS_2D
            IF (Rank_horizontal_right.GE.0) THEN
 ! ## 1 ## send right densities in the right edge
               rbufer(1:n1) = diagnostics_neutral(n)%activated_collision(p)%ionization_rate_local(c_indx_x_max, c_indx_y_min:c_indx_y_max)
-              CALL MPI_SEND(rbufer, n1, MPI_REAL, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+              CALL MPI_SEND(rbufer, n1, MPI_REAL, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, ierr) 
            END IF
 
            IF (Rank_horizontal_left.GE.0) THEN
 ! ## 2 ## send left densities in the left edge
               rbufer(1:n1) = diagnostics_neutral(n)%activated_collision(p)%ionization_rate_local(c_indx_x_min, c_indx_y_min:c_indx_y_max)
-              CALL MPI_SEND(rbufer, n1, MPI_REAL, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+              CALL MPI_SEND(rbufer, n1, MPI_REAL, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, ierr) 
            END IF
 
            IF (Rank_horizontal_left.GE.0) THEN
@@ -2104,13 +2104,13 @@ SUBROUTINE SAVE_en_COLLISIONS_2D
            IF (Rank_horizontal_above.GE.0) THEN
 ! ## 5 ## send up densities in the top edge
               rbufer(1:n3) = diagnostics_neutral(n)%activated_collision(p)%ionization_rate_local(c_indx_x_min:c_indx_x_max, c_indx_y_max)
-              CALL MPI_SEND(rbufer, n3, MPI_REAL, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+              CALL MPI_SEND(rbufer, n3, MPI_REAL, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, ierr) 
            END IF
 
            IF (Rank_horizontal_below.GE.0) THEN
 ! ## 6 ## send down densities in the bottom edge
               rbufer(1:n3) = diagnostics_neutral(n)%activated_collision(p)%ionization_rate_local(c_indx_x_min:c_indx_x_max, c_indx_y_min)
-              CALL MPI_SEND(rbufer, n3, MPI_REAL, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+              CALL MPI_SEND(rbufer, n3, MPI_REAL, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, ierr) 
            END IF
 
            IF (Rank_horizontal_below.GE.0) THEN
@@ -2154,13 +2154,13 @@ SUBROUTINE SAVE_en_COLLISIONS_2D
            IF (Rank_horizontal_right.GE.0) THEN
 ! ## 3 ## send right densities in the right edge
               rbufer(1:n1) = diagnostics_neutral(n)%activated_collision(p)%ionization_rate_local(c_indx_x_max, c_indx_y_min:c_indx_y_max)
-              CALL MPI_SEND(rbufer, n1, MPI_REAL, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+              CALL MPI_SEND(rbufer, n1, MPI_REAL, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, ierr) 
            END IF
 
            IF (Rank_horizontal_left.GE.0) THEN
 ! ## 4 ## send left densities in the left edge
               rbufer(1:n1) = diagnostics_neutral(n)%activated_collision(p)%ionization_rate_local(c_indx_x_min, c_indx_y_min:c_indx_y_max)
-              CALL MPI_SEND(rbufer, n1, MPI_REAL, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+              CALL MPI_SEND(rbufer, n1, MPI_REAL, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, ierr) 
            END IF
 
            IF (ALLOCATED(rbufer)) DEALLOCATE(rbufer, STAT=ALLOC_ERR)
@@ -2185,13 +2185,13 @@ SUBROUTINE SAVE_en_COLLISIONS_2D
            IF (Rank_horizontal_above.GE.0) THEN
 ! ## 7 ## send up densities in the top edge
               rbufer(1:n3) = diagnostics_neutral(n)%activated_collision(p)%ionization_rate_local(c_indx_x_min:c_indx_x_max, c_indx_y_max)
-              CALL MPI_SEND(rbufer, n3, MPI_REAL, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+              CALL MPI_SEND(rbufer, n3, MPI_REAL, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, ierr) 
            END IF
 
            IF (Rank_horizontal_below.GE.0) THEN
 ! ## 8 ## send down densities in the bottom edge
               rbufer(1:n3) = diagnostics_neutral(n)%activated_collision(p)%ionization_rate_local(c_indx_x_min:c_indx_x_max, c_indx_y_min)
-              CALL MPI_SEND(rbufer, n3, MPI_REAL, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+              CALL MPI_SEND(rbufer, n3, MPI_REAL, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, ierr) 
            END IF
 
         END IF
@@ -2293,9 +2293,9 @@ SUBROUTINE SAVE_IONS_COLLIDED_WITH_BOUNDARY_OBJECTS
   USE IonParticles, ONLY : N_spec, M_i_amu
   USE Snapshots
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER ierr
   INTEGER stattus(MPI_STATUS_SIZE)
@@ -2455,9 +2455,9 @@ SUBROUTINE SAVE_ELECTRONS_COLLIDED_WITH_BOUNDARY_OBJECTS
                                  & delta_x_m, V_scale_ms, N_scale_part_m3, e_colls_with_bo, whole_object
   USE Snapshots
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER ierr
   INTEGER stattus(MPI_STATUS_SIZE)

--- a/src/pic2d_SnapshotsAvg.f90
+++ b/src/pic2d_SnapshotsAvg.f90
@@ -9,9 +9,10 @@ SUBROUTINE INITIATE_AVERAGED_SNAPSHOTS
   USE Checkpoints, ONLY : use_checkpoint
   USE MCCollisions, ONLY : N_neutral_spec, collision_e_neutral, en_collisions_turned_off
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER errcode,ierr
 
@@ -287,9 +288,10 @@ SUBROUTINE COLLECT_F_EX_EY_FOR_AVERAGED_SNAPSHOT
   USE Snapshots, ONLY : diagnostics_neutral
 
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER ierr
   INTEGER stattus(MPI_STATUS_SIZE)
@@ -565,7 +567,7 @@ SUBROUTINE COLLECT_F_EX_EY_FOR_AVERAGED_SNAPSHOT
               pos1 = pos1 + recsize
            END DO
 
-           CALL MPI_SEND(rbufer, bufsize, MPI_REAL, field_master, Rank_of_process, MPI_COMM_WORLD, request, ierr) 
+           CALL MPI_SEND(rbufer, bufsize, MPI_REAL, field_master, Rank_of_process, MPI_COMM_WORLD, ierr) 
 
            DEALLOCATE(rbufer, STAT = ALLOC_ERR)
         
@@ -607,6 +609,8 @@ SUBROUTINE COLLECT_ELECTRON_DATA_FOR_AVERAGED_SNAPSHOT
   USE AvgSnapshots
   USE Snapshots, ONLY : cs_N, cs_VX, cs_VY, cs_VZ, cs_WX, cs_WY, cs_WZ, cs_VXVY, cs_VXVZ, cs_VYVZ, cs_QX, cs_QY, cs_QZ
   USE ClusterAndItsBoundaries
+
+  use mpi
 
   IMPLICIT NONE
 
@@ -738,6 +742,8 @@ SUBROUTINE COLLECT_ION_DATA_FOR_AVERAGED_SNAPSHOT(s)
   USE AvgSnapshots
   USE Snapshots, ONLY : cs_N, cs_VX, cs_VY, cs_VZ, cs_WX, cs_WY, cs_WZ, cs_VXVY, cs_VXVZ, cs_VYVZ, cs_QX, cs_QY, cs_QZ
   USE ClusterAndItsBoundaries
+
+  use mpi
 
   IMPLICIT NONE
 
@@ -891,9 +897,10 @@ SUBROUTINE CREATE_AVERAGED_SNAPSHOT
   USE MCCollisions, ONLY : N_neutral_spec, neutral, collision_e_neutral
   USE Snapshots, ONLY : diagnostics_neutral
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER ierr
 

--- a/src/pic2d_VelocityDistributions.f90
+++ b/src/pic2d_VelocityDistributions.f90
@@ -8,9 +8,10 @@ SUBROUTINE CALCULATE_ELECTRON_VDF
   USE ClusterAndItsBoundaries
   USE Snapshots
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER ierr
   INTEGER stattus(MPI_STATUS_SIZE)
@@ -216,9 +217,10 @@ SUBROUTINE CALCULATE_ION_VDF
   USE ClusterAndItsBoundaries
   USE Snapshots
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER ierr
   INTEGER stattus(MPI_STATUS_SIZE)

--- a/src/pic2d_enCollisionsGeneralProc.f90
+++ b/src/pic2d_enCollisionsGeneralProc.f90
@@ -10,9 +10,9 @@ SUBROUTINE INITIATE_ELECTRON_NEUTRAL_COLLISIONS
   USE IonParticles, ONLY : N_spec, Ms
 !  USE ClusterAndItsBoundaries
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER errcode,ierr
  
@@ -344,9 +344,9 @@ SUBROUTINE PERFORM_ELECTRON_NEUTRAL_COLLISIONS
 
 !  USE ParallelOperationValues
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER errcode,ierr
   INTEGER stattus(MPI_STATUS_SIZE)
@@ -768,9 +768,9 @@ SUBROUTINE SAVE_en_COLLISIONS
   USE ElectronParticles, ONLY : N_electrons
   USE CurrentProblemValues, ONLY : T_cntr
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER ierr
   INTEGER stattus(MPI_STATUS_SIZE)
@@ -1071,9 +1071,9 @@ SUBROUTINE COLLECT_ELECTRON_DENSITY_FOR_COLL_FREQS
   USE AvgSnapshots
   USE CurrentProblemValues, ONLY : T_cntr
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER ierr
   INTEGER stattus(MPI_STATUS_SIZE)
@@ -1169,9 +1169,9 @@ SUBROUTINE SYNCHRONIZE_REAL_ARRAY_IN_OVERLAP_NODES(arr)
   USE ParallelOperationValues
   USE ClusterAndItsBoundaries
 
-  IMPLICIT NONE
+  use mpi
 
-  INCLUDE 'mpif.h'
+  IMPLICIT NONE
 
   INTEGER ierr
   INTEGER stattus(MPI_STATUS_SIZE)
@@ -1206,7 +1206,7 @@ SUBROUTINE SYNCHRONIZE_REAL_ARRAY_IN_OVERLAP_NODES(arr)
         pos2=n1
         rbufer(pos1:pos2) = arr(c_indx_x_max, c_indx_y_min:c_indx_y_max)
 
-        CALL MPI_SEND(rbufer, n1, MPI_REAL, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+        CALL MPI_SEND(rbufer, n1, MPI_REAL, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, ierr) 
      END IF
 
      IF (Rank_horizontal_left.GE.0) THEN
@@ -1215,7 +1215,7 @@ SUBROUTINE SYNCHRONIZE_REAL_ARRAY_IN_OVERLAP_NODES(arr)
         pos2=n1
         rbufer(pos1:pos2) = arr(c_indx_x_min, c_indx_y_min:c_indx_y_max)
 
-        CALL MPI_SEND(rbufer, n1, MPI_REAL, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+        CALL MPI_SEND(rbufer, n1, MPI_REAL, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, ierr) 
      END IF
 
      IF (Rank_horizontal_left.GE.0) THEN
@@ -1247,7 +1247,7 @@ SUBROUTINE SYNCHRONIZE_REAL_ARRAY_IN_OVERLAP_NODES(arr)
         pos2=n3
         rbufer(pos1:pos2) = arr(c_indx_x_min:c_indx_x_max, c_indx_y_max)
 
-        CALL MPI_SEND(rbufer, n3, MPI_REAL, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+        CALL MPI_SEND(rbufer, n3, MPI_REAL, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, ierr) 
      END IF
 
      IF (Rank_horizontal_below.GE.0) THEN
@@ -1256,7 +1256,7 @@ SUBROUTINE SYNCHRONIZE_REAL_ARRAY_IN_OVERLAP_NODES(arr)
         pos2=n3
         rbufer(pos1:pos2) = arr(c_indx_x_min:c_indx_x_max, c_indx_y_min)
 
-        CALL MPI_SEND(rbufer, n3, MPI_REAL, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+        CALL MPI_SEND(rbufer, n3, MPI_REAL, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, ierr) 
      END IF
 
      IF (Rank_horizontal_below.GE.0) THEN
@@ -1311,7 +1311,7 @@ SUBROUTINE SYNCHRONIZE_REAL_ARRAY_IN_OVERLAP_NODES(arr)
         pos2=n1
         rbufer(pos1:pos2) = arr(c_indx_x_max, c_indx_y_min:c_indx_y_max)
 
-        CALL MPI_SEND(rbufer, n1, MPI_REAL, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+        CALL MPI_SEND(rbufer, n1, MPI_REAL, Rank_horizontal_right, Rank_horizontal, COMM_HORIZONTAL, ierr) 
      END IF
 
      IF (Rank_horizontal_left.GE.0) THEN
@@ -1320,7 +1320,7 @@ SUBROUTINE SYNCHRONIZE_REAL_ARRAY_IN_OVERLAP_NODES(arr)
         pos2=n1
         rbufer(pos1:pos2) = arr(c_indx_x_min, c_indx_y_min:c_indx_y_max)
 
-        CALL MPI_SEND(rbufer, n1, MPI_REAL, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+        CALL MPI_SEND(rbufer, n1, MPI_REAL, Rank_horizontal_left, Rank_horizontal, COMM_HORIZONTAL, ierr) 
      END IF
 
      IF (ALLOCATED(rbufer)) DEALLOCATE(rbufer, STAT=ALLOC_ERR)
@@ -1350,7 +1350,7 @@ SUBROUTINE SYNCHRONIZE_REAL_ARRAY_IN_OVERLAP_NODES(arr)
         pos2=n3
         rbufer(pos1:pos2) = arr(c_indx_x_min:c_indx_x_max, c_indx_y_max)
 
-        CALL MPI_SEND(rbufer, n3, MPI_REAL, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+        CALL MPI_SEND(rbufer, n3, MPI_REAL, Rank_horizontal_above, Rank_horizontal, COMM_HORIZONTAL, ierr) 
      END IF
 
      IF (Rank_horizontal_below.GE.0) THEN
@@ -1359,7 +1359,7 @@ SUBROUTINE SYNCHRONIZE_REAL_ARRAY_IN_OVERLAP_NODES(arr)
         pos2=n3
         rbufer(pos1:pos2) = arr(c_indx_x_min:c_indx_x_max, c_indx_y_min)
 
-        CALL MPI_SEND(rbufer, n3, MPI_REAL, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, request, ierr) 
+        CALL MPI_SEND(rbufer, n3, MPI_REAL, Rank_horizontal_below, Rank_horizontal, COMM_HORIZONTAL, ierr) 
      END IF
 
   END IF   !###   IF (WHITE_CLUSTER) THEN

--- a/src/pic2d_inCollisionsGeneralProc.f90
+++ b/src/pic2d_inCollisionsGeneralProc.f90
@@ -8,9 +8,10 @@ SUBROUTINE INITIATE_ION_NEUTRAL_COLLISIONS
   USE IonParticles, ONLY : N_spec, Ms
 !  USE ClusterAndItsBoundaries
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER ierr
 
@@ -98,6 +99,8 @@ SUBROUTINE INITIATE_in_COLL_DIAGNOSTICS
   USE CurrentProblemValues, ONLY : Start_T_cntr, N_subcycles, delta_t_s
   USE Checkpoints, ONLY : use_checkpoint
   USE IonParticles, ONLY : N_spec
+
+  use mpi
 
   IMPLICIT NONE
 
@@ -199,9 +202,10 @@ SUBROUTINE SAVE_in_COLLISIONS
   USE IonParticles, ONLY : N_spec, N_ions
   USE CurrentProblemValues, ONLY : T_cntr
 
+  use mpi
+
   IMPLICIT NONE
 
-  INCLUDE 'mpif.h'
 
   INTEGER ierr
 !  INTEGER stattus(MPI_STATUS_SIZE)

--- a/src/pic2d_inCollisionsSpecificProc.f90
+++ b/src/pic2d_inCollisionsSpecificProc.f90
@@ -54,9 +54,10 @@ subroutine PERFORM_RESONANT_CHARGE_EXCHANGE
   USE CurrentProblemValues, ONLY : energy_factor_eV, delta_t_s, N_subcycles, V_scale_ms
   USE rng_wrapper
 
+  use mpi
+
   IMPLICIT NONE
 
-!  INCLUDE 'mpif.h'
 !  INTEGER ierr
 !  INTEGER stattus(MPI_STATUS_SIZE)
 


### PR DESCRIPTION
We were getting compilation errors when building EDIPIC2D with gfortran >= 10. It happens when two or more of the same MPI calls appear in the same subroutine but are used with different data types. Here is an example (not from EDIPIC2D, though):

```
  call MPI_BCAST(n,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
  call MPI_BCAST(tt0,1,MPI_DOUBLE_PRECISION,0,MPI_COMM_WORLD,ierr)

```
This is very common and happens all over the code. The errors come from the fact that EDIPIC2D uses `include 'mpif.h'` instead of the proper MPI Fortran module. A way to turn those errors into simple warnings was to add `-fallow-argument-mismatch` as a compiler option but this is not an ideal solution. We should use the "mpi" Fortran module instead.

In this PR, all "include 'mpif.h'" were replaced with "use mpi" to have proper Fortran interfaces to the generic MPI subroutines. This avoids the errors put out by the gfortran compiler (version >+ 10) when calling the same MPI subroutine with different datatypes. There was also a problem with all the MPI_SEND() calls having an extra argument ("request") that should not be there. The extra argument was removed. 


